### PR TITLE
ci: add least-privilege permissions and SHA-pin third-party actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,10 +35,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo registry + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           key: benchmarks
 
@@ -62,7 +62,7 @@ jobs:
           maturin develop --release -E dev,bench
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@93bbfdc546455345ae00c6f4e100a37838b37bcf # v4.14.0
         with:
           mode: walltime
           token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Build wheels (manylinux)
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1.51.0
         with:
           target: ${{ matrix.target }}
           # -i targets a single Python version so each matrix cell
@@ -95,7 +95,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Build wheels (macOS)
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1.51.0
         with:
           target: ${{ matrix.target }}
           # -i targets a single Python version so each matrix cell
@@ -122,7 +122,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Build wheels (Windows)
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1.51.0
         with:
           # -i targets a single Python version so each matrix cell
           # produces exactly one wheel; maturin otherwise picks up
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@3e2bdf6ba6453a61e649744019b8a2d906c7eb38 # v1.51.0
         with:
           command: sdist
           args: --out dist
@@ -167,4 +167,4 @@ jobs:
           merge-multiple: true
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -34,10 +37,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo registry + build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           # Per-OS key so compiled artifacts don't leak across
           # Linux / macOS / Windows caches.


### PR DESCRIPTION
Adds `permissions: contents: read` at the top level of test.yml, which was the only workflow missing an explicit permissions block (inherits broad repo defaults otherwise).

SHA-pins every third-party `uses:` reference per the supply-chain rule:

- test.yml          dtolnay/rust-toolchain (stable branch tip)
                    Swatinem/rust-cache (v2.8.1)
- benchmarks.yml    dtolnay/rust-toolchain, Swatinem/rust-cache,
                    CodSpeedHQ/action (v4.14.0)
- release.yml       PyO3/maturin-action (v1.51.0) x4,
                    pypa/gh-action-pypi-publish (release/v1 tip)

Tag comments retained after the SHA for readability. First-party actions/*, github/* references remain on floating tags (exempt by policy, immutable by GitHub guarantee).

Note: benchmarks.yml runs on `pull_request` with `secrets.CODSPEED_TOKEN`, which a PR author can exfiltrate by modifying the workflow file in their PR. Not fixed here — requires a product decision between dropping the PR trigger (loses CodSpeed's PR comparison) or a workflow_run split. Handle in a follow-up PR.