### PR TITLE
fix: enforce panic=unwind, wrap oxidase, propagate pending-job exceptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,4 @@ oxidase = { git = "https://github.com/branchseer/oxidase", rev = "045ea46b604cee
 lto = true
 codegen-units = 1
 strip = true
+panic = "unwind" # required: see src/reentrance.rs — PyO3 catch_unwind + Guard safety

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -710,11 +710,7 @@ class Context:
                     try:
                         while True:
                             # §7.4 step 1: drain microtasks first.
-                            rc = self._engine_ctx.run_pending_jobs()
-                            if rc < 0:
-                                raise QuickJSError(
-                                    "pending-job execution reported an error"
-                                )
+                            self._engine_ctx.run_pending_jobs()
 
                             # §7.4 step 2: check promise state.
                             state = self._engine_ctx.promise_state(inner)

--- a/src/context.rs
+++ b/src/context.rs
@@ -415,19 +415,21 @@ impl QjsContext {
     /// executed. The driving loop polls this between
     /// promise-state checks.
     fn run_pending_jobs(&self) -> PyResult<i32> {
-        let runtime = self.context()?.runtime().clone();
+        let context = self.context()?;
+        let runtime = context.runtime().clone();
         let mut count: i32 = 0;
         loop {
             match runtime.execute_pending_job() {
                 Ok(true) => count += 1,
                 Ok(false) => break,
                 Err(_) => {
-                    // Job-level exception: the reaction threw.
-                    // QuickJS reports this via a return value; we
-                    // surface it as a negative count so the Python
-                    // driving loop can decide whether to raise.
-                    count = -1;
-                    break;
+                    return with_active_ctx(context, |ctx| {
+                        let caught = ctx.catch();
+                        Err(js_error_from_caught(
+                            ctx,
+                            rquickjs::CaughtError::Value(caught),
+                        ))
+                    });
                 }
             }
         }

--- a/src/host_fn.rs
+++ b/src/host_fn.rs
@@ -175,7 +175,15 @@ fn dispatch_async_host_fn<'js>(
                 to: "js",
                 message: Some(format!("async dispatcher raised: {}", e)),
             })?;
-        Ok(result.extract::<i32>().unwrap_or(0))
+        let rc: i32 = result.extract::<i32>().map_err(|e| rquickjs::Error::IntoJs {
+            from: "python",
+            to: "js",
+            message: Some(format!(
+                "async dispatcher returned a non-integer value (expected 0 or -1): {}",
+                e
+            )),
+        })?;
+        Ok(rc)
     })?;
 
     if rc < 0 {

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -388,24 +388,25 @@ pub(crate) fn maybe_strip_ts(key: &str, source: &str) -> Result<String, String> 
         return Ok(source.to_string());
     };
 
-    let allocator = oxidase::Allocator::default();
-    let mut buf = source.to_string();
-    let ret = oxidase::transpile(&allocator, source_type, &mut buf);
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let allocator = oxidase::Allocator::default();
+        let mut buf = source.to_string();
+        let ret = oxidase::transpile(&allocator, source_type, &mut buf);
+        (buf, ret.parser_panicked, ret.parser_errors
+            .iter()
+            .map(|d| d.to_string())
+            .collect::<Vec<_>>())
+    }));
 
-    if ret.parser_panicked {
-        // Parser bailed — the output is unsafe to use. Stringify
-        // whatever diagnostics came back; if there are none, give
-        // a generic message so the user at least knows which file.
-        let msg = if ret.parser_errors.is_empty() {
+    let (buf, panicked, errors) = outcome.map_err(|_| {
+        format!("oxidase panicked unexpectedly while parsing {}", key)
+    })?;
+    
+    if panicked {
+        let msg = if errors.is_empty() {
             format!("oxidase failed to parse {}", key)
         } else {
-            let joined = ret
-                .parser_errors
-                .iter()
-                .map(|d| d.to_string())
-                .collect::<Vec<_>>()
-                .join("; ");
-            format!("TypeScript parse error in {}: {}", key, joined)
+            format!("TypeScript parse error in {}: {}", key, errors.join("; "))
         };
         return Err(msg);
     }

--- a/src/reentrance.rs
+++ b/src/reentrance.rs
@@ -15,6 +15,14 @@
 //! its real `'js` scope. Removing or refactoring this machinery
 //! will break `test_reentrant_eval_from_host_function` — the v0.2
 //! tripwire that pinned it.
+//!
+//! SAFETY INVARIANT: requires `panic = "unwind"` (enforced in Cargo.toml).
+//! PyO3 wraps #[pymethods] calls in catch_unwind. Under panic=unwind, a
+//! panicking host function unwinds through the Guard (clearing the thread-local)
+//! before PyO3 catches it — the program recovers with a clean slot. Without
+//! this, PyO3 could recover the program while the thread-local still holds a
+//! dead Ctx<'static>, and the next reentrant call on that runtime would be a
+//! use-after-free.
 
 use pyo3::prelude::*;
 use rquickjs::{Context, Ctx};

--- a/src/reentrance.rs
+++ b/src/reentrance.rs
@@ -16,7 +16,7 @@
 //! will break `test_reentrant_eval_from_host_function` — the v0.2
 //! tripwire that pinned it.
 //!
-//! SAFETY INVARIANT: requires `panic = "unwind"` (enforced in Cargo.toml).
+//! Requires `panic = "unwind"` (enforced in Cargo.toml).
 //! PyO3 wraps #[pymethods] calls in catch_unwind. Under panic=unwind, a
 //! panicking host function unwinds through the Guard (clearing the thread-local)
 //! before PyO3 catches it — the program recovers with a clean slot. Without

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -351,10 +351,11 @@ async def test_throw_in_then_callback_propagates_as_js_error() -> None:
         with rt.new_context() as ctx:
             with pytest.raises(JSError) as exc_info:
                 await ctx.eval_async(
-                    "await Promise.resolve().then(() => { throw new RangeError('boom from then'); })"
+                    "await Promise.resolve()"
+                    ".then(() => { throw new RangeError('boom'); })"
                 )
             assert exc_info.value.name == "RangeError"
-            assert "boom from then" in exc_info.value.message
+            assert "boom" in exc_info.value.message
 
 
 async def test_cumulative_timeout_two_calls_within_budget() -> None:

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -9,6 +9,7 @@ import pytest
 from quickjs_rs import (
     ConcurrentEvalError,
     DeadlockError,
+    JSError,
     Runtime,
 )
 
@@ -340,6 +341,20 @@ async def test_promise_chain_resolves_synchronously() -> None:
                 "await Promise.resolve(1).then(x => x + 1)"
             )
             assert result == 2
+
+
+async def test_throw_in_then_callback_propagates_as_js_error() -> None:
+    """A throw inside a .then() reaction fires as a pending job.
+    run_pending_jobs must propagate the actual JS exception — name,
+    message, stack — not swallow it or raise a generic string."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+            with pytest.raises(JSError) as exc_info:
+                await ctx.eval_async(
+                    "await Promise.resolve().then(() => { throw new RangeError('boom from then'); })"
+                )
+            assert exc_info.value.name == "RangeError"
+            assert "boom from then" in exc_info.value.message
 
 
 async def test_cumulative_timeout_two_calls_within_budget() -> None:


### PR DESCRIPTION
### Summary
#### Enforced panic = "unwind" in release builds (Cargo.toml, reentrance.rs):
In reentrance.rs, we temporarily cast Ctx<'js> to Ctx<'static> and depend on a guard to clean up a thread-local when the scope exits. Normally, PyO3’s catch_unwind at #[pymethods] boundaries can recover from a panic—but if panic = "unwind" isn’t enabled, that guard might not run first. When that happens, we can end up leaving behind a dangling pointer in thread-local storage.

#### Wrapped oxidase::transpile in catch_unwind (src/modules.rs):
oxidase is a git-pinned dependency maintained by a single author and not published on crates.io. If it panics, that panic would cross the #[pymethods] boundary as a PanicException instead of a QuickJSError. We now wrap the call in catch_unwind so any panic is caught and converted into a QuickJSError during install().

#### run_pending_jobs now surfaces real JS exceptions (src/context.rs, quickjs_rs/context.py):
Previously, if a .then() callback threw, it would just return -1, and the loop would raise a generic QuickJSError("pending-job execution reported an error") with no useful details. Now we capture the actual JS exception and raise it as a JSError, including its name, message, and stack. Added a test: test_throw_in_then_callback_propagates_as_js_error.

#### Removed unwrap_or(0) from the async dispatcher (src/host_fn.rs):
Before, if the dispatcher returned something that wasn’t an integer, we’d quietly treat it as success. That could create a PendingResolver that never resolves, eventually leading to a DeadlockError with no clue why. Now we fail fast and surface it immediately as an IntoJs error.