### PR TITLE
refactor(runtime): make Runtime.install the only module install API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ stdlib = ModuleScope({
 
 with Runtime() as rt:
     with rt.new_context() as ctx:
-        ctx.install(stdlib)
+        rt.install(stdlib)
         assert await ctx.eval_async("""
             const { slugify } = await import("@agent/utils");
             const { MAX_RETRIES } = await import("@agent/config");
@@ -88,7 +88,7 @@ Shared deps are declared by spreading (`**utils.modules`) into each scope that n
 Source strings whose key ends in `.ts`, `.mts`, `.cts`, or `.tsx` are type-stripped at `install()` time via oxidase. Enums, namespaces, and parameter properties are transformed; plain type annotations erase to whitespace. No type checking — run `tsc --noEmit` separately if you want that.
 
 ```python
-ctx.install(ModuleScope({
+rt.install(ModuleScope({
     "@util": ModuleScope({
         "index.ts": """
             export enum Mode { Strict = 1, Loose = 2 }

--- a/quickjs_rs/__init__.py
+++ b/quickjs_rs/__init__.py
@@ -27,7 +27,7 @@ __version__ = "0.4.0.dev0"
 
 # Public API surface. v0.3 names (Runtime, Context, Handle, errors,
 # Undefined) ship at tag v0.3.0. v0.4 adds ModuleScope here; the
-# runtime wiring (Context.install, module=True eval) lands in later
+# runtime wiring (Runtime.install, module=True eval) lands in later
 # steps of spec/module-loading.md §10.
 __all__ = [
     "Runtime",

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -24,7 +24,6 @@ from quickjs_rs.errors import (
 )
 from quickjs_rs.globals import Globals
 from quickjs_rs.handle import Handle
-from quickjs_rs.modules import ModuleScope
 from quickjs_rs.runtime import Runtime
 
 
@@ -176,7 +175,10 @@ class Context:
         inner: _engine.QjsHandle
         try:
             inner = self._engine_ctx.eval_handle(
-                code, module=module, strict=strict, filename=filename
+                code,
+                module=module,
+                strict=strict,
+                filename=filename,
             )
         except _engine.JSError as e:
             name, message, stack = e.args
@@ -239,7 +241,10 @@ class Context:
         result: Any
         try:
             result = self._engine_ctx.eval(
-                code, module=module, strict=strict, filename=filename
+                code,
+                module=module,
+                strict=strict,
+                filename=filename,
             )
         except _engine.JSError as e:
             name, message, stack = e.args
@@ -400,60 +405,6 @@ class Context:
             return self.register(js_name, f, is_async=is_async)
 
         return decorator
-
-    # ---- Module installation -----------------------------------------
-
-    def install(self, scope: ModuleScope) -> None:
-        """Register modules in the runtime's module store so that
-        ``module=True`` eval can ``import`` from them. See
-        spec/module-loading.md §5.3.
-
-        Walks ``scope`` recursively. str-valued entries become JS
-        source files; ModuleScope-valued entries become nested
-        scopes with bare-specifier names. The backing store is
-        per-runtime (rquickjs's ``set_loader`` is a runtime-level
-        API), so all contexts on the same runtime see the same
-        module set.
-
-        Additive: multiple calls insert into the same store. A name
-        that hasn't been imported yet can be overwritten; a name
-        that has already been imported is a silent no-op (QuickJS
-        caches module records per canonical path).
-
-        No-op on an empty scope — valid as a base for composition.
-        """
-        if self._closed:
-            raise QuickJSError("context is closed")
-        self._install_recursive(scope, scope_path="")
-
-    def _install_recursive(self, scope: ModuleScope, scope_path: str) -> None:
-        engine_rt = self._runtime._engine_rt
-        for key, value in scope.modules.items():
-            if isinstance(value, str):
-                canonical = key if scope_path == "" else f"{scope_path}/{key}"
-                try:
-                    engine_rt.add_module_source(
-                        scope_path, key, canonical, value
-                    )
-                except _engine.QuickJSError as e:
-                    # §5.5: TypeScript parse errors surface here
-                    # (install time), not at eval. Rebrand the raw
-                    # engine error as the public QuickJSError with
-                    # the same message + __cause__ for traceback.
-                    raise QuickJSError(str(e)) from e
-            elif isinstance(value, ModuleScope):
-                engine_rt.register_subscope(scope_path, key)
-                child_path = key if scope_path == "" else f"{scope_path}/{key}"
-                self._install_recursive(value, scope_path=child_path)
-            else:
-                # ModuleScope.__post_init__ already forbids other
-                # types — this branch is unreachable for a validated
-                # scope. Defensive guard for anyone constructing a
-                # ModuleScope via object.__setattr__ shenanigans.
-                raise TypeError(
-                    f"ModuleScope entry {key!r}: expected str | ModuleScope, "
-                    f"got {type(value).__name__}"
-                )
 
     # ---- Async eval --------------------------------------------------
 
@@ -638,7 +589,8 @@ class Context:
         try:
             if module:
                 inner = self._engine_ctx.eval_module_async(
-                    code, filename=filename
+                    code,
+                    filename=filename,
                 )
             else:
                 inner = self._engine_ctx.eval_handle(

--- a/quickjs_rs/modules.py
+++ b/quickjs_rs/modules.py
@@ -74,7 +74,7 @@ class ModuleScope:
 
         # Pure-dependency container (only ModuleScope values, no str
         # entries, no index.js required). Common shape for the root
-        # scope passed to ctx.install.
+        # scope passed to rt.install.
         ModuleScope({
             "@agent/utils": ModuleScope({"index.js": "..."}),
             "@agent/fs": ModuleScope({"index.js": "..."}),

--- a/quickjs_rs/runtime.py
+++ b/quickjs_rs/runtime.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import quickjs_rs._engine as _engine
 from quickjs_rs.errors import QuickJSError
+from quickjs_rs.modules import ModuleScope
 
 
 class Runtime:
@@ -84,6 +85,37 @@ class Runtime:
             self._contexts.remove(ctx)
         except ValueError:
             pass
+
+    def install(self, scope: ModuleScope) -> None:
+        """Register modules in this runtime's shared module store.
+
+        Any context created from this runtime can import installed
+        modules (subject to QuickJS module-cache semantics).
+        """
+        if self._closed:
+            raise QuickJSError("runtime is closed")
+        self._install_recursive(scope, scope_path="")
+
+    def _install_recursive(self, scope: ModuleScope, scope_path: str) -> None:
+        for key, value in scope.modules.items():
+            if isinstance(value, str):
+                canonical = key if scope_path == "" else f"{scope_path}/{key}"
+                try:
+                    self._engine_rt.add_module_source(
+                        scope_path, key, canonical, value
+                    )
+                except _engine.QuickJSError as e:
+                    # §5.5: TypeScript parse errors surface at install.
+                    raise QuickJSError(str(e)) from e
+            elif isinstance(value, ModuleScope):
+                self._engine_rt.register_subscope(scope_path, key)
+                child_path = key if scope_path == "" else f"{scope_path}/{key}"
+                self._install_recursive(value, scope_path=child_path)
+            else:
+                raise TypeError(
+                    f"ModuleScope entry {key!r}: expected str | ModuleScope, "
+                    f"got {type(value).__name__}"
+                )
 
     def run_pending_jobs(self) -> int:
         raise NotImplementedError("run_pending_jobs lands with async support (§7.4).")

--- a/spec/module-loading.md
+++ b/spec/module-loading.md
@@ -31,7 +31,7 @@ stdlib = ModuleScope({
 
 with Runtime() as rt:
     with rt.new_context() as ctx:
-        ctx.install(stdlib)
+        rt.install(stdlib)
 
         @ctx.function
         async def _readFile(path: str) -> str:
@@ -120,7 +120,7 @@ class ModuleScope:
         })
 
         # Pure-dependency root (only ModuleScope entries, no str).
-        # This is the common shape of what you hand to ctx.install.
+        # This is the common shape of what you hand to rt.install.
         ModuleScope({
             "@agent/utils": ModuleScope({"index.js": "..."}),
             "@agent/fs": ModuleScope({"index.js": "..."}),
@@ -132,7 +132,7 @@ class ModuleScope:
 **Validation at construction:**
 
 - A ModuleScope that contains at least one `str` value must include an index module — any one of `index.js`, `index.mjs`, `index.cjs`, `index.ts`, `index.mts`, `index.cts`, `index.jsx`, `index.tsx`. That's what a bare `import "<scope-name>"` resolves to from the parent scope. A scope without any `index.<ext>` can't be imported by name. TypeScript extensions are accepted as entry points and stripped at install time (§5.5). When multiple index extensions are present in the same scope (unusual but legal), the resolver picks the first match in the order listed above, with JS variants ahead of TS.
-- Scopes that contain only `ModuleScope` values (pure dependency containers) don't need `index.js`. They aren't themselves importable targets — they're registry wrappers. This is how a root scope handed to `ctx.install` typically looks.
+- Scopes that contain only `ModuleScope` values (pure dependency containers) don't need `index.js`. They aren't themselves importable targets — they're registry wrappers. This is how a root scope handed to `rt.install` typically looks.
 - `str` keys may contain `/` (POSIX-style path within the scope's file tree): `"lib/util.js"`, `"tests/deep/nested.js"`. Path normalization is purely a resolver concern; the dict key stays as-given.
 - Any key, at any depth, must not start with `./` or `../`. Those are relative specifiers used in JS import statements, never valid as dict keys.
 - Nested `ModuleScope` values may themselves contain `str` and/or `ModuleScope` children. Nesting is recursive and unbounded — whatever the dependency graph requires.
@@ -166,7 +166,7 @@ ModuleScope({
 
 # Valid — pure-dependency container (only ModuleScope values → no
 #         index.js required). Common shape for the root scope
-#         passed to ctx.install.
+#         passed to rt.install.
 ModuleScope({
     "@agent/utils": ModuleScope({"index.js": "export const U = 1;"}),
     "@agent/fs": ModuleScope({"index.js": "export const F = 2;"}),
@@ -184,7 +184,7 @@ ModuleScope({"@agent/fs": 42})  # TypeError
 
 A single-file module (`ModuleScope({"lodash": "export const x = 1;"})`) from earlier drafts no longer parses. `lodash` as a str at root would be a file — but the root scope has no `index.js` sibling, so validation fails. Wrap the source in a ModuleScope (`ModuleScope({"lodash": ModuleScope({"index.js": "export const x = 1;"})})`) to declare a single-file dep. The tradeoff keeps the two-namespaces rule clean — str is always a file, ModuleScope is always a dep.
 
-### 3.2 Context.install
+### 3.2 Runtime.install
 
 ```python
 class Context:
@@ -289,7 +289,7 @@ Relative specifiers never match a dependency. Bare specifiers never match a file
 
 Given `import "X" from referrer "Y"`:
 
-1. Identify the scope `S` that contains `Y`. For a file `"path/to/foo.js"` within scope `Sname`, the containing scope is `Sname` and the referrer's position within it is `path/to/foo.js`. For `"<eval>"`, the containing scope is the root scope installed via `ctx.install` and the position is the root (empty path).
+1. Identify the scope `S` that contains `Y`. For a file `"path/to/foo.js"` within scope `Sname`, the containing scope is `Sname` and the referrer's position within it is `path/to/foo.js`. For `"<eval>"`, the containing scope is the root scope installed via `rt.install` and the position is the root (empty path).
 2. If `X` starts with `./` or `../`:
    - Compute `normalized = posixpath.normpath(posixpath.dirname(position_in_S) + "/" + X)`.
    - If `normalized` starts with `"../"` or equals `".."` → **error**: the specifier escapes scope `S`.
@@ -377,7 +377,7 @@ import "X" from "Y" where Y lives at position P within scope S:
       (X never matches a str entry — deps only)
 ```
 
-`"<eval>"` is the referrer for code passed to `ctx.eval_async(module=True)`. Its containing scope is the root scope installed via `ctx.install`; its position within that scope is the empty string (the root directory). So `./foo.js` from eval normalizes to `foo.js` and looks for a root-level str entry; `@agent/fs` from eval looks for a root-level ModuleScope entry; `../anything` fails (escape past root).
+`"<eval>"` is the referrer for code passed to `ctx.eval_async(module=True)`. Its containing scope is the root scope installed via `rt.install`; its position within that scope is the empty string (the root directory). So `./foo.js` from eval normalizes to `foo.js` and looks for a root-level str entry; `@agent/fs` from eval looks for a root-level ModuleScope entry; `../anything` fails (escape past root).
 
 ## 5. Rust extension additions
 
@@ -402,7 +402,7 @@ The backing store holds a flattened view of the scope tree. At install time, Pyt
 * Each `str` entry under a canonical path that concatenates the containing scope's canonical path plus the entry's key (which may itself contain `/` if the user used a POSIX path): `"scope1/scope2/.../lib/util.js"`.
 * Each `ModuleScope` entry as a scope record whose canonical path is the joined scope-path. Scope records also store, for each direct dict key, its kind (`File` or `Scope`) and — for `File` entries — the full POSIX path (so the resolver can do `normpath` against `str` entries only).
 
-The root scope (the one passed to `ctx.install`) has the empty canonical path `""`. A file `"lib/util.js"` inside `@agent/fs` shows up as `"@agent/fs/lib/util.js"`. A file inside `@agent/fs/@peer` shows up as `"@agent/fs/@peer/index.js"`.
+The root scope (the one passed to `rt.install`) has the empty canonical path `""`. A file `"lib/util.js"` inside `@agent/fs` shows up as `"@agent/fs/lib/util.js"`. A file inside `@agent/fs/@peer` shows up as `"@agent/fs/@peer/index.js"`.
 
 ```rust
 /// Tree registry populated from Python's ModuleScope at install time.
@@ -511,7 +511,7 @@ impl Loader for FlatModuleStore {
 }
 ```
 
-The backing store construction (from `Context.install`) walks the `ModuleScope` recursively. At each scope, Python declares the scope's direct entries with their kinds; for each `str` entry it then calls `add_source` with the canonical path (joined scope path + the str key as-given, which may contain `/`):
+The backing store construction (from `Runtime.install`) walks the `ModuleScope` recursively. At each scope, Python declares the scope's direct entries with their kinds; for each `str` entry it then calls `add_source` with the canonical path (joined scope path + the str key as-given, which may contain `/`):
 
 ```python
 def _install_scope(self, scope: ModuleScope, scope_path: str) -> None:
@@ -543,7 +543,7 @@ def install(self, scope: ModuleScope) -> None:
 
 ### 5.3 New QjsRuntime / QjsContext methods
 
-The backing `FlatModuleStore` lives on the runtime (§11 open-decision 4 — `set_loader` is per-runtime in rquickjs). Two methods on `QjsRuntime` mutate the store at install time; one method on `QjsContext` evaluates code as an ES module.
+The backing `FlatModuleStore` lives on the runtime (`set_loader` is per-runtime in rquickjs). quickjs-rs exposes `Runtime.install()` as the owning API. Two methods on `QjsRuntime` mutate the store at install time; one method on `QjsContext` evaluates code as an ES module.
 
 ```rust
 #[pymethods]
@@ -586,7 +586,7 @@ impl QjsContext {
 }
 ```
 
-See §5.2 for the Python `Context.install()` recursion that drives these two methods.
+See §5.2 for the Python `Runtime.install()` recursion that drives these two methods.
 
 Additive: each call inserts into the backing `FlatModuleStore`. No guard, no flag, no error on repeated calls. Re-inserting a name that hasn't been imported yet overwrites the previous source. Re-inserting a name that has been imported is a no-op (QuickJS module cache takes precedence). A second `install` with a different root ModuleScope also merges into the same store — users who want isolated module sets should use separate runtimes.
 
@@ -629,13 +629,13 @@ async def eval_async(self, code, *, module=False, **kw):
 
 ### 5.5 TypeScript stripping
 
-Files whose scope-entry key ends in `.ts`, `.mts`, `.cts`, or `.tsx` are run through [oxidase](https://github.com/branchseer/oxidase) at `Context.install()` time. Oxidase erases type annotations, transforms enums / namespaces / parameter properties, and returns a plain JS source that QuickJS can execute. Plain JS extensions (`.js`, `.mjs`, `.cjs`, `.jsx`) and any other extensions pass through unchanged.
+Files whose scope-entry key ends in `.ts`, `.mts`, `.cts`, or `.tsx` are run through [oxidase](https://github.com/branchseer/oxidase) at `Runtime.install()` time. Oxidase erases type annotations, transforms enums / namespaces / parameter properties, and returns a plain JS source that QuickJS can execute. Plain JS extensions (`.js`, `.mjs`, `.cjs`, `.jsx`) and any other extensions pass through unchanged.
 
 Key behaviors:
 
 * **Per-file decision.** The scope dict's key determines stripping. A scope can freely mix `.ts` and `.js` entries — each file is handled according to its own extension. The canonical path stored in `FlatModuleStore.sources` preserves the original extension (e.g. `"@util/helpers.ts"`), so QuickJS stack traces point at the source the user wrote.
 * **Specifiers are preserved.** Oxidase does not rewrite import specifiers. `import { x } from "./foo.ts"` stays `"./foo.ts"` in the stripped output, and the resolver looks up `"foo.ts"` against the scope's file set — matching the dict key literally. There is no `.ts → .js` fallback; keys and specifiers must agree character-for-character.
-* **Errors surface at install time.** Oxidase parses the source during stripping, so a TypeScript syntax error raises `QuickJSError` from `ctx.install(scope)` rather than later at `ctx.eval_async(..., module=True)`. The error message includes the scope-key filename and oxidase's diagnostic text. This is a nicer failure mode than plain-JS syntax errors, which still surface at eval time (QuickJS parses lazily).
+* **Errors surface at install time.** Oxidase parses the source during stripping, so a TypeScript syntax error raises `QuickJSError` from `rt.install(scope)` rather than later at `ctx.eval_async(..., module=True)`. The error message includes the scope-key filename and oxidase's diagnostic text. This is a nicer failure mode than plain-JS syntax errors, which still surface at eval time (QuickJS parses lazily).
 * **No type checking.** Oxidase only strips types — it does not validate them. `const x: number = "hi"` installs and runs successfully (produces `const x         = "hi"`). Run `tsc --noEmit` separately if you want type checking.
 * **Index-file extensions.** Because `index.ts` is a legitimate entry point, §3.1's "scope with str entries must declare an index module" rule accepts any `index.<ext>` where `<ext>` is one of `js`, `mjs`, `cjs`, `ts`, `mts`, `cts`, `jsx`, `tsx`. When a bare specifier resolves to a scope, the resolver picks the first matching `index.<ext>` in that preference order. The order means a scope with both `index.js` and `index.ts` prefers `.js` — a situation that shouldn't arise in normal authorship but is unambiguous if it does.
 
@@ -667,7 +667,7 @@ The dependency is declared in `Cargo.toml` as a pinned git rev (not a floating b
 ### 6.1 Registration → import → evaluation
 
 ```
-Python: ctx.install(scope)
+Python: rt.install(scope)
   → recurse the scope tree, calling declare_scope at each scope
     and add_source at each str entry
   → Rust: FlatModuleStore.sources and .scopes get populated with
@@ -700,7 +700,7 @@ Python: ctx.eval_async("import { readFile } from '@agent/fs'; ...", module=True)
 
 QuickJS caches module records per context. Once `@agent/fs` is imported, subsequent `import "@agent/fs"` returns the cached module — the loader is NOT called again. This is correct ES module behavior (modules are singletons per realm).
 
-Consequence for additive `install()`: calling `ctx.install()` with a new source for a module name that's already been imported is a no-op — QuickJS serves the cached version. However, installing a module name that hasn't been imported yet works normally, even if other modules have already been imported. This means the pattern "install base modules, eval some code, install additional modules, eval more code" works correctly as long as the additional modules are genuinely new names.
+Consequence for additive `install()`: calling `rt.install()` with a new source for a module name that's already been imported is a no-op — QuickJS serves the cached version. However, installing a module name that hasn't been imported yet works normally, even if other modules have already been imported. This means the pattern "install base modules, eval some code, install additional modules, eval more code" works correctly as long as the additional modules are genuinely new names.
 
 ### 6.3 Module + script interaction
 
@@ -883,7 +883,7 @@ async def test_module_acceptance():
                     ],
                 }
 
-            ctx.install(stdlib)
+            rt.install(stdlib)
 
             # The motivating pattern — with real imports
             await ctx.eval_async("""
@@ -951,7 +951,7 @@ async def test_module_acceptance():
             async def _swarm(tasks: list, concurrency: int) -> dict:
                 return {"completed": 0, "failed": 0, "results": []}
 
-            ctx.install(test_stdlib)
+            rt.install(test_stdlib)
 
             await ctx.eval_async("""
                 import { MAX_RETRIES } from "@agent/config";
@@ -966,7 +966,7 @@ async def test_module_acceptance():
         })
 
         with rt.new_context() as ctx:
-            ctx.install(restricted)
+            rt.install(restricted)
             try:
                 await ctx.eval_async("""
                     import { readFile } from "@agent/fs";
@@ -997,7 +997,7 @@ async def test_module_acceptance():
             # @agent/utils directly because root doesn't declare it.
         })
         with rt.new_context() as ctx:
-            ctx.install(recursive)
+            rt.install(recursive)
             await ctx.eval_async("""
                 import { message } from "@app";
                 globalThis.msg = message;
@@ -1022,7 +1022,7 @@ async def test_module_acceptance():
 
 2. **ModuleScope class (Python only):** frozen dataclass with validation. No Rust changes. Commit as `api: ModuleScope type with validation`.
 
-3. **Static registry + install:** implement `FlatModuleStore` in Rust (Resolver + Loader) with the scope-local resolver from §4. Expose `add_source` + `declare_scope` on `QjsRuntime`. Wire `Context.install()` as a recursive walk in Python. First test: single-file module at root, import a constant. Commit as `engine+api: module registry — install + single-file import`.
+3. **Static registry + install:** implement `FlatModuleStore` in Rust (Resolver + Loader) with the scope-local resolver from §4. Expose `add_source` + `declare_scope` on `QjsRuntime`. Wire `Runtime.install()` as a recursive walk in Python. First test: single-file module at root, import a constant. Commit as `engine+api: module registry — install + single-file import`.
 
 4. **Nested scopes and self-contained deps:** extend tests for multi-file scopes with internal `./x.js` imports and for scopes that carry their own dependency scopes. The resolver already handles both from step 3 — this step is primarily test coverage + docs. Commit as `engine: nested scope resolution — ./relative + recursive deps`.
 
@@ -1042,7 +1042,7 @@ async def test_module_acceptance():
 
 - **Module names: any string or namespaced?** The spec allows any string as a module name (`"lodash"`, `"@agent/fs"`, `"my-thing"`). No enforcement of `@scope/name` convention. Users pick their own naming. This is simpler but means collisions between independently-authored module sets are the user's problem. Lean: keep it open, document the `@scope/name` convention as recommended but not enforced.
 
-- **Install on Runtime vs Context?** Resolved: `ctx.install()` is the API, but rquickjs's `set_loader` operates at the Runtime level. The `FlatModuleStore` is set on the runtime at creation and shared across all contexts on that runtime. Multiple `install()` calls from any context add to the same backing store. This means all contexts on the same runtime see the same module set. If different contexts need different module sets, use separate runtimes (8.6 µs each). This is acceptable for v0.4 — per-context module filtering is a v0.5 concern if it ever surfaces as a real need.
+- **Install on Runtime vs Context?** Resolved: module installation is runtime-scoped (`Runtime.install()`). rquickjs's `set_loader` is runtime-level, and all contexts on the same runtime see the same module set. If different contexts need different module sets, use separate runtimes.
 
 ## 12. Out of scope for v0.4
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -56,7 +56,7 @@ def test_pure_dependency_root_is_valid_without_index_js() -> None:
     """§3.1: a scope containing only ModuleScope values (no str
     entries) doesn't need its own index.js — it isn't a module
     target, just a registry wrapper. This is the common shape of
-    what gets passed to ctx.install."""
+    what gets passed to rt.install."""
     scope = ModuleScope(
         {
             "@agent/config": ModuleScope(
@@ -475,7 +475,7 @@ async def test_install_bare_specifier_from_eval() -> None:
     """
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/config": ModuleScope(
@@ -503,7 +503,7 @@ async def test_install_relative_specifier_within_scope() -> None:
     """
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/utils": ModuleScope(
@@ -549,7 +549,7 @@ async def test_install_posix_subdirectory_and_parent_traversal() -> None:
             # turn reaches up to `../index.js` (= `index.js` at
             # scope root) to import `ROOT`. Exercises both
             # directions of POSIX traversal within a scope.
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/app": ModuleScope(
@@ -591,7 +591,7 @@ async def test_same_filename_in_sibling_scopes_resolves_independently() -> None:
     source."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@a": ModuleScope(
@@ -638,7 +638,7 @@ async def test_relative_import_from_top_level_eval_resolves_in_root_scope() -> N
     satisfies validation) plus a sibling file we import."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "index.js": "export const ENTRY = true;",
@@ -661,7 +661,7 @@ async def test_relative_import_from_eval_for_missing_file_raises() -> None:
     such file → ResolveError surfaces as JSError."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@x": ModuleScope({"index.js": "export const Y = 1;"})})
             )
             with pytest.raises(JSError, match="missing.js"):
@@ -677,7 +677,7 @@ async def test_parent_traversal_past_scope_root_raises() -> None:
     from ``normalize_path`` in src/modules.rs."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@x": ModuleScope(
@@ -704,7 +704,7 @@ async def test_top_level_eval_cannot_escape_root_with_dotdot() -> None:
     "outside" the installed set."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@x": ModuleScope({"index.js": "export const Y = 1;"})})
             )
             with pytest.raises(JSError, match="escapes module scope root"):
@@ -723,7 +723,7 @@ async def test_scope_can_import_its_own_declared_dep_but_not_transitive() -> Non
     the resolver does NOT walk ancestors or consult the root."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@a": ModuleScope(
@@ -767,7 +767,7 @@ async def test_scope_cannot_reach_transitive_dep_directly() -> None:
     correctness of scope-local resolution."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@a": ModuleScope(
@@ -809,7 +809,7 @@ async def test_adding_transitive_dep_directly_makes_it_importable() -> None:
     c_scope = ModuleScope({"index.js": "export const C = 'c';"})
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@a": ModuleScope(
@@ -872,7 +872,7 @@ async def test_shared_dep_via_spread_resolves_in_both_scopes() -> None:
     )
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(main)
+            rt.install(main)
             await ctx.eval_async(
                 """
                 import { id } from "@agent/utils";
@@ -897,7 +897,7 @@ async def test_module_eval_returns_none() -> None:
     undefined; the only way to surface a value is globalThis."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@x": ModuleScope({"index.js": "export const V = 42;"})})
             )
             result = await ctx.eval_async(
@@ -912,7 +912,7 @@ async def test_module_scoped_let_is_not_visible_in_subsequent_eval() -> None:
     A subsequent script-mode eval cannot see them."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@x": ModuleScope({"index.js": "export const Y = 1;"})})
             )
             await ctx.eval_async(
@@ -928,7 +928,7 @@ async def test_module_globalThis_assignment_visible_in_script_eval() -> None:
     script-mode eval."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@x": ModuleScope({"index.js": "export const Y = 7;"})})
             )
             await ctx.eval_async(
@@ -944,7 +944,7 @@ async def test_script_global_visible_in_module() -> None:
     names and ``ctx.globals[...]`` values flow into modules."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@x": ModuleScope({"index.js": "export const K = 1;"})})
             )
             ctx.eval("globalThis.fromScript = 'hello'")
@@ -973,7 +973,7 @@ async def test_module_top_level_await_with_async_host_function() -> None:
                 await asyncio.sleep(0.001)
                 return {"one": 1, "two": 2}[key]
 
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/lookup": ModuleScope(
@@ -1022,7 +1022,7 @@ async def test_module_importing_module_that_uses_await() -> None:
             # Self-containment: consumer must carry its own copy of
             # provider in its dict. The top-level scope doesn't
             # leak into consumer.
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/provider": provider,
@@ -1055,7 +1055,7 @@ async def test_import_non_registered_module_raises() -> None:
     """§8: missing module → JSError at eval time."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@x": ModuleScope({"index.js": "export const Y = 1;"})})
             )
             with pytest.raises(JSError, match="@nope"):
@@ -1073,7 +1073,7 @@ async def test_syntax_error_in_module_surfaces_at_eval_time() -> None:
         with rt.new_context() as ctx:
             # install() must NOT raise even though the source is
             # clearly malformed.
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@broken": ModuleScope(
@@ -1101,11 +1101,11 @@ async def test_reinstall_before_import_takes_new_source() -> None:
     the import sees the new value."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@cfg": ModuleScope({"index.js": "export const V = 1;"})})
             )
             # Re-install under the same canonical path BEFORE any import.
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {"@cfg": ModuleScope({"index.js": "export const V = 999;"})}
                 )
@@ -1124,7 +1124,7 @@ async def test_reinstall_after_import_is_no_op_cache_wins() -> None:
     expected to know not to rely on hot-reloading module sources."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@cfg": ModuleScope({"index.js": "export const V = 1;"})})
             )
             await ctx.eval_async(
@@ -1133,7 +1133,7 @@ async def test_reinstall_after_import_is_no_op_cache_wins() -> None:
             )
             assert ctx.eval("first") == 1
             # Attempted swap — ignored by QuickJS's module cache.
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {"@cfg": ModuleScope({"index.js": "export const V = 999;"})}
                 )
@@ -1155,10 +1155,10 @@ async def test_two_installs_both_importable() -> None:
     first's modules, just merges into the same backing store."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@a": ModuleScope({"index.js": "export const A = 1;"})})
             )
-            ctx.install(
+            rt.install(
                 ModuleScope({"@b": ModuleScope({"index.js": "export const B = 2;"})})
             )
             await ctx.eval_async(
@@ -1178,7 +1178,7 @@ async def test_install_after_eval_is_visible_to_next_eval() -> None:
     wasn't imported earlier (which would hit the cache)."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope({"@a": ModuleScope({"index.js": "export const A = 1;"})})
             )
             await ctx.eval_async(
@@ -1187,7 +1187,7 @@ async def test_install_after_eval_is_visible_to_next_eval() -> None:
             )
             assert ctx.eval("first") == 1
             # Install a NEW name after an eval has happened.
-            ctx.install(
+            rt.install(
                 ModuleScope({"@b": ModuleScope({"index.js": "export const B = 10;"})})
             )
             await ctx.eval_async(
@@ -1223,7 +1223,7 @@ async def test_spread_override_replaces_module_end_to_end() -> None:
     )
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(test_scope)
+            rt.install(test_scope)
             await ctx.eval_async(
                 """
                 import { ENV } from "@agent/config";
@@ -1254,7 +1254,7 @@ async def test_comprehension_removal_makes_module_unreachable() -> None:
     )
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(restricted)
+            rt.install(restricted)
             # Safe module still works.
             await ctx.eval_async(
                 'import { safe } from "@agent/safe"; globalThis.r = safe;',
@@ -1286,7 +1286,7 @@ async def test_ts_file_with_type_annotations_imports_and_runs() -> None:
     valid entry point alongside index.js."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@util": ModuleScope(
@@ -1325,7 +1325,7 @@ async def test_tsx_file_strips_types() -> None:
     primary thing under test."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@ui": ModuleScope(
@@ -1357,7 +1357,7 @@ async def test_ts_enum_is_transpiled_to_runtime_value() -> None:
     actually works at runtime."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@e": ModuleScope(
@@ -1392,7 +1392,7 @@ async def test_ts_interface_has_no_runtime_artifact() -> None:
             # The interface declaration itself is erased; no
             # binding is produced. The `User` reference in the
             # annotation is also erased with it.
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@m": ModuleScope(
@@ -1439,11 +1439,11 @@ def test_ts_syntax_error_surfaces_at_install_time() -> None:
     Note this test is sync — install() is sync, and we don't need
     an eval to trigger the failure."""
     with Runtime() as rt:
-        with rt.new_context() as ctx:
+        with rt.new_context():
             from quickjs_rs import QuickJSError
 
             with pytest.raises(QuickJSError, match="TypeScript parse error"):
-                ctx.install(
+                rt.install(
                     ModuleScope(
                         {
                             "@broken": ModuleScope(
@@ -1464,7 +1464,7 @@ async def test_mixed_ts_and_js_files_in_same_scope() -> None:
     an install-time strip decision."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@m": ModuleScope(
@@ -1503,7 +1503,7 @@ async def test_ts_to_ts_relative_import_preserves_extension() -> None:
     registered as "other.ts"."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@m": ModuleScope(
@@ -1536,7 +1536,7 @@ async def test_ts_to_js_relative_import_works() -> None:
     per-file and doesn't corrupt cross-extension imports."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@m": ModuleScope(
@@ -1578,7 +1578,7 @@ async def test_dynamic_import_resolves_bare_specifier() -> None:
     exports."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/config": ModuleScope(
@@ -1605,7 +1605,7 @@ async def test_dynamic_import_of_relative_specifier_from_root_eval() -> None:
     str entries must declare one (§3.1)."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "index.js": "export const marker = true;",
@@ -1631,7 +1631,7 @@ async def test_dynamic_import_unknown_specifier_rejects() -> None:
     `@/skills/<name>` lookup."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(ModuleScope({"index.js": "export const x = 1;"}))
+            rt.install(ModuleScope({"index.js": "export const x = 1;"}))
             with pytest.raises(JSError):
                 await ctx.eval_async(
                     """
@@ -1648,7 +1648,7 @@ async def test_dynamic_import_of_ts_entrypoint_strips_types() -> None:
     see the same stripped source as static import."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/ts": ModuleScope(
@@ -1682,7 +1682,7 @@ async def test_dynamic_import_is_cached() -> None:
     importee should read as 1 twice, not 2."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/stateful": ModuleScope(
@@ -1734,7 +1734,7 @@ async def test_dynamic_import_basic() -> None:
     """
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/utils": ModuleScope(
@@ -1770,7 +1770,7 @@ async def test_dynamic_import_from_script_mode() -> None:
     """
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/utils": ModuleScope(
@@ -1799,7 +1799,7 @@ async def test_dynamic_import_variable_specifier() -> None:
     is worth knowing."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@agent/utils": ModuleScope(
@@ -1825,7 +1825,7 @@ async def test_dynamic_import_not_found() -> None:
     the normal async driving loop as a JSError."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@real": ModuleScope(
@@ -1852,7 +1852,7 @@ async def test_dynamic_import_within_scope() -> None:
     scope. Same path a static relative import would take."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@m": ModuleScope(
@@ -1888,7 +1888,7 @@ async def test_dynamic_import_typescript() -> None:
     entry in the scope."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
-            ctx.install(
+            rt.install(
                 ModuleScope(
                     {
                         "@m": ModuleScope(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -518,7 +518,7 @@ async def test_module_acceptance() -> None:
                     ],
                 }
 
-            ctx.install(stdlib)
+            rt.install(stdlib)
 
             # The motivating pattern — imports across scopes, top-
             # level await calling async host functions, results
@@ -615,7 +615,7 @@ async def test_module_acceptance() -> None:
                 async def _swarm(tasks: list, concurrency: int) -> dict:
                     return {"completed": 0, "failed": 0, "results": []}
 
-                ctx.install(test_stdlib)
+                rt_override.install(test_stdlib)
                 await ctx.eval_async(
                     """
                     import { MAX_RETRIES } from "@agent/config";
@@ -632,7 +632,7 @@ async def test_module_acceptance() -> None:
 
         with Runtime() as rt_restricted:
             with rt_restricted.new_context() as ctx:
-                ctx.install(restricted)
+                rt_restricted.install(restricted)
                 with pytest.raises(JSError, match="@agent/fs"):
                     await ctx.eval_async(
                         """
@@ -673,7 +673,7 @@ async def test_module_acceptance() -> None:
         )
         with Runtime() as rt_recursive:
             with rt_recursive.new_context() as ctx:
-                ctx.install(recursive)
+                rt_recursive.install(recursive)
                 await ctx.eval_async(
                     """
                     import { message } from "@app";
@@ -693,5 +693,4 @@ async def test_module_acceptance() -> None:
                         """,
                         module=True,
                     )
-
 


### PR DESCRIPTION
## Summary

Makes module installation a runtime-owned API by introducing `Runtime.install(...)` as the sole install entrypoint and removing `Context.install(...)`.

The goal is to align the public API with QuickJS/rquickjs loader semantics, where module loader configuration is runtime-scoped. This is an intentional breaking change.

## Changes

### Runtime API

- Added `Runtime.install(scope: ModuleScope)` as the owning installation path in `quickjs_rs/runtime.py`.
- Moved recursive module-store population logic into `Runtime`.

### Context API

- Removed `Context.install(...)` from `quickjs_rs/context.py`.
- Kept context eval behavior unchanged aside from install ownership.

### Callsite Migration

- Updated tests to use `rt.install(...)` instead of `ctx.install(...)`.
- Updated examples/docs/spec text to reflect `Runtime.install(...)` naming and semantics.
- Updated module-related API commentary in package/module docs to match the new surface.
