### PR TITLE
fix(security): sanitize host callback errors exposed to js

### DIFF
--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import time
-import traceback
 from collections.abc import Callable
 from types import TracebackType
 from typing import Any
@@ -26,6 +25,8 @@ from quickjs_rs.globals import Globals
 from quickjs_rs.handle import Handle
 from quickjs_rs.modules import ModuleScope
 from quickjs_rs.runtime import Runtime
+
+_HOST_ERROR_SANITIZED_MESSAGE = "Host function failed"
 
 
 def _detect_is_async(fn: Callable[..., Any]) -> bool:
@@ -945,10 +946,10 @@ class Context:
             except BaseException as exc:
                 resolve_ok = False
                 self._last_host_exception = exc
-                err_message = str(exc)
-                err_stack = "".join(
-                    traceback.format_exception(type(exc), exc, exc.__traceback__)
-                )
+                # Preserve internals in Python (__cause__), but expose
+                # only a stable sanitized message over the JS boundary.
+                err_message = _HOST_ERROR_SANITIZED_MESSAGE
+                err_stack = None
 
             try:
                 if resolve_ok:
@@ -983,17 +984,15 @@ class Context:
         if fn is None:
             raise _engine.JSError(
                 "HostError",
-                f"no host function registered for fn_id={fn_id}",
+                _HOST_ERROR_SANITIZED_MESSAGE,
                 None,
             )
         try:
             return fn(*args)
         except BaseException as exc:
             self._last_host_exception = exc
-            # Match v0.2: message is str(exc), not the ExcType: str(exc)
-            # prefix. The Python type is preserved through __cause__ on
-            # the HostError the user actually catches.
-            stack = "".join(
-                traceback.format_exception(type(exc), exc, exc.__traceback__)
-            )
-            raise _engine.JSError("HostError", str(exc), stack) from None
+            # Preserve original exception in __cause__, while
+            # sanitizing the JS-visible HostError payload.
+            raise _engine.JSError(
+                "HostError", _HOST_ERROR_SANITIZED_MESSAGE, None
+            ) from None

--- a/src/host_fn.rs
+++ b/src/host_fn.rs
@@ -189,7 +189,7 @@ fn dispatch_async_host_fn<'js>(
             let _ = resolve; // drop to free
             let exc = rquickjs::Exception::from_message(
                 ctx.clone(),
-                "async host dispatcher rejected",
+                "Host function failed",
             )?;
             let _ = exc.as_object().set(PredefinedAtom::Name, "HostError");
             let _: Value<'_> = reject_fn.call((exc.into_value(),))?;

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -171,7 +171,7 @@ async def test_eval_async_propagates_js_rejection() -> None:
 
             with pytest.raises(HostError) as excinfo:
                 await ctx.eval_async("await fail()")
-            assert "from async host" in excinfo.value.message
+            assert excinfo.value.message == "Host function failed"
             assert isinstance(excinfo.value.__cause__, ValueError)
 
 

--- a/tests/test_async_host_functions.py
+++ b/tests/test_async_host_functions.py
@@ -402,7 +402,7 @@ async def test_async_host_function_raises_surfaces_hosterror() -> None:
 
             with pytest.raises(HostError) as excinfo:
                 await ctx.eval_async("await broken()")
-            assert "specific failure mode" in excinfo.value.message
+            assert excinfo.value.message == "Host function failed"
             assert isinstance(excinfo.value.__cause__, CustomError)
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -96,7 +96,7 @@ def test_js_catches_hosterror_and_reads_name_and_message() -> None:
                     "try { raiser(); 'unreachable'; }"
                     " catch (e) { `${e.name}: ${e.message}` }"
                 )
-                == "HostError: inner detail"
+                == "HostError: Host function failed"
             )
 
 

--- a/tests/test_host_functions.py
+++ b/tests/test_host_functions.py
@@ -71,7 +71,7 @@ def test_host_function_exception_surfaces_as_hosterror() -> None:
             try:
                 ctx.eval("explode()")
             except HostError as exc:
-                assert "bang" in exc.message
+                assert exc.message == "Host function failed"
             else:
                 raise AssertionError("expected HostError")
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -104,7 +104,7 @@ def test_smoke_primitives() -> None:
                     "try { boom(); 'unreachable'; }"
                     " catch (e) { e.name + ': ' + e.message }"
                 )
-                == "HostError: from python"
+                == "HostError: Host function failed"
             )
 
             # JS-thrown TypeError (not a host error) surfaces as JSError
@@ -238,7 +238,7 @@ def test_acceptance() -> None:
                 catch (e) { e.name + ': ' + e.message }
             """
                 )
-                == "HostError: from python"
+                == "HostError: Host function failed"
             )
 
             # Memory limit: see the note in test_smoke_primitives for
@@ -693,5 +693,4 @@ async def test_module_acceptance() -> None:
                         """,
                         module=True,
                     )
-
 


### PR DESCRIPTION
## Summary

Hardens host-callback error propagation by sanitizing bridge errors that are exposed to JavaScript. Instead of forwarding raw callback exception messages/tracebacks, the JS-visible payload is now a stable generic `HostError` message.

## Changes

### Host Error Sanitization
- Added a single sanitized boundary message constant in `quickjs_rs/context.py`.
- Updated sync callback error path (`_dispatch_host_call`) to emit sanitized `HostError` payloads.
- Updated async callback error path (`_run_async_host_call`) to reject with sanitized `HostError` payloads.
- Updated async dispatcher failure rejection message in `src/host_fn.rs` to match the same sanitized message.

### Test Updates
- Updated tests that previously asserted raw host exception text to assert sanitized message behavior:
  - `tests/test_async.py`
  - `tests/test_async_host_functions.py`
  - `tests/test_exceptions.py`
  - `tests/test_host_functions.py`
  - `tests/test_smoke.py`

### Security Impact
- Preserves Python-side exception causality (`HostError.__cause__`) for internal debugging.
- Reduces leakage of internal exception content into JS/model-visible contexts by default.
