### PR TITLE
fix(reentrance): preserve context identity in reentrant eval

### DIFF
--- a/src/reentrance.rs
+++ b/src/reentrance.rs
@@ -3,11 +3,9 @@
 //! rquickjs's non-parallel runtime guard is a non-reentrant RefCell
 //! (per-runtime, not per-context), so nested `Context::with` from
 //! within a host-fn callback panics with "RefCell already borrowed".
-//! We stash the currently-active `Ctx<'static>` (lifetime laundered,
-//! same pattern as rquickjs::Persistent) keyed by raw JSRuntime
-//! pointer in a thread-local: any QjsHandle on any QjsContext
-//! sharing that runtime picks up the stashed Ctx during reentrance
-//! and skips the nested `with` entirely.
+//! We track which runtimes are currently entered on this thread:
+//! reentrant calls on an active runtime skip `Context::with` and
+//! build a temporary `Ctx` from the *requested* context pointer.
 //!
 //! The `'static` lifetime is a lie maintained by bracketing in
 //! `with_active_ctx` — the slot is set on entry and cleared on exit
@@ -15,6 +13,9 @@
 //! its real `'js` scope. Removing or refactoring this machinery
 //! will break `test_reentrant_eval_from_host_function` — the v0.2
 //! tripwire that pinned it.
+//!
+//! This preserves reentrancy while keeping context identity correct
+//! across sibling contexts sharing one runtime.
 //!
 //! Requires `panic = "unwind"` (enforced in Cargo.toml).
 //! PyO3 wraps #[pymethods] calls in catch_unwind. Under panic=unwind, a
@@ -27,49 +28,46 @@
 use pyo3::prelude::*;
 use rquickjs::{Context, Ctx};
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 thread_local! {
-    static ACTIVE_CTX_BY_RT: RefCell<HashMap<usize, Ctx<'static>>> =
-        RefCell::new(HashMap::new());
+    static ACTIVE_RUNTIMES: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
 }
 
-/// Run `f` with a live `Ctx<'js>` from `context`. If there's already
-/// an active Ctx for this runtime (reentrant call from a host fn),
-/// use that directly instead of re-locking via `Context::with`.
+/// Run `f` with a live `Ctx<'js>` from `context`.
+///
+/// If this runtime is already active on the current thread (reentrant
+/// call from a host fn), skip `Context::with` and synthesize a
+/// temporary `Ctx` from `context`'s raw pointer under the already-held
+/// runtime lock.
 pub(crate) fn with_active_ctx<F, R>(context: &Context, f: F) -> PyResult<R>
 where
     F: FnOnce(&Ctx<'_>) -> PyResult<R>,
 {
     let rt_key = context.get_runtime_ptr() as usize;
 
-    // Fast path: reentrant call — use the stashed Ctx. We clone it
-    // out of the map so the closure can borrow the clone; the
-    // stashed entry stays in place for any deeper nesting.
-    let stashed: Option<Ctx<'static>> = ACTIVE_CTX_BY_RT
-        .with(|cell| cell.borrow().get(&rt_key).cloned());
-    if let Some(stashed) = stashed {
-        // Shrink 'static back down to the local borrow. Sound because
-        // we're inside the outer with's closure body right now.
-        let as_short: &Ctx<'_> = unsafe {
-            core::mem::transmute::<&Ctx<'static>, &Ctx<'_>>(&stashed)
-        };
-        return f(as_short);
+    // Fast path: runtime lock is already held by an outer
+    // with_active_ctx frame on this thread.
+    let reentrant = ACTIVE_RUNTIMES.with(|cell| cell.borrow().contains(&rt_key));
+    if reentrant {
+        // Safety: presence in ACTIVE_RUNTIMES means we're running
+        // inside an outer Context::with for this runtime. The raw
+        // pointer is from `context` itself, and the borrowed Ctx
+        // stays scoped to this call.
+        let reentrant_ctx = unsafe { Ctx::from_raw(context.as_raw()) };
+        return f(&reentrant_ctx);
     }
 
-    // Slow path: enter Context::with, publish the Ctx into the
-    // thread-local, clear on exit (incl. panic unwind via RAII).
+    // Slow path: enter Context::with and mark this runtime active
+    // until we leave the closure (including unwind via Drop).
     context.with(|ctx| {
-        let static_ctx: Ctx<'static> = unsafe {
-            core::mem::transmute::<Ctx<'_>, Ctx<'static>>(ctx.clone())
-        };
-        ACTIVE_CTX_BY_RT.with(|cell| {
-            cell.borrow_mut().insert(rt_key, static_ctx);
+        ACTIVE_RUNTIMES.with(|cell| {
+            cell.borrow_mut().insert(rt_key);
         });
         struct Guard(usize);
         impl Drop for Guard {
             fn drop(&mut self) {
-                ACTIVE_CTX_BY_RT.with(|cell| {
+                ACTIVE_RUNTIMES.with(|cell| {
                     cell.borrow_mut().remove(&self.0);
                 });
             }

--- a/tests/test_reentrance.py
+++ b/tests/test_reentrance.py
@@ -1,0 +1,96 @@
+"""Reentrant cross-context isolation tripwires.
+
+"Reentrant context" here means an inner QuickJS operation is started
+before an outer one has unwound, while both share the same runtime.
+Typical shape: JS in context A calls a Python host function, and that
+host function calls ``ctx_b.eval(...)`` (sync or async path). The key
+invariant is context identity: the inner operation must execute against
+the explicitly requested context (B), never whichever sibling context
+was active at outer entry (A).
+"""
+
+from __future__ import annotations
+
+from quickjs_rs import Runtime
+
+
+def test_reentrant_eval_uses_requested_context_for_reads() -> None:
+    """A host fn registered on context A that calls ``b.eval`` must run in
+    B's global object, not A's."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx_a, rt.new_context() as ctx_b:
+            ctx_a.globals["tag"] = "A"
+            ctx_b.globals["tag"] = "B"
+
+            @ctx_a.function(name="call_b")
+            def call_b() -> str:
+                return ctx_b.eval("tag")
+
+            assert ctx_a.eval("call_b()") == "B"
+
+
+def test_reentrant_eval_uses_requested_context_for_writes() -> None:
+    """Writes through ``b.eval`` from an A-registered host fn must mutate
+    B, leaving A unchanged."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx_a, rt.new_context() as ctx_b:
+            ctx_a.globals["tag"] = "A"
+            ctx_b.globals["tag"] = "B"
+
+            @ctx_a.function(name="write_b")
+            def write_b() -> None:
+                ctx_b.eval("tag = 'B2'")
+
+            ctx_a.eval("write_b()")
+            assert ctx_a.eval("tag") == "A"
+            assert ctx_b.eval("tag") == "B2"
+
+
+async def test_async_host_fn_cross_context_eval_reads_requested_context() -> None:
+    """Cross-context read isolation under async host callbacks."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx_a, rt.new_context() as ctx_b:
+            ctx_a.globals["tag"] = "A"
+            ctx_b.globals["tag"] = "B"
+
+            @ctx_a.function(name="call_b", is_async=True)
+            async def call_b() -> str:
+                return ctx_b.eval("tag")
+
+            assert await ctx_a.eval_async("await call_b()") == "B"
+
+
+async def test_async_host_fn_cross_context_eval_writes_requested_context() -> None:
+    """Cross-context write isolation under async host callbacks."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx_a, rt.new_context() as ctx_b:
+            ctx_a.globals["tag"] = "A"
+            ctx_b.globals["tag"] = "B"
+
+            @ctx_a.function(name="write_b", is_async=True)
+            async def write_b() -> None:
+                ctx_b.eval("tag = 'B2'")
+
+            await ctx_a.eval_async("await write_b()")
+            assert ctx_a.eval("tag") == "A"
+            assert ctx_b.eval("tag") == "B2"
+
+
+async def test_async_host_fn_nested_reentrancy_preserves_context_identity() -> None:
+    """Async path variant of the reentrant cross-context identity seam."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx_a, rt.new_context() as ctx_b:
+            ctx_a.globals["tag"] = "A"
+            ctx_b.globals["tag"] = "B"
+
+            @ctx_b.function(name="call_a")
+            def call_a() -> str:
+                return ctx_a.eval("tag")
+
+            @ctx_a.function(name="via_b", is_async=True)
+            async def via_b() -> str:
+                # Reentrant chain inside async task:
+                # ctx_a async host fn -> ctx_b.eval -> ctx_b host fn -> ctx_a.eval.
+                return ctx_b.eval("call_a()")
+
+            assert await ctx_a.eval_async("await via_b()") == "A"


### PR DESCRIPTION
## Summary

Fixes a cross-context isolation bug in reentrant eval when multiple contexts share one QuickJS runtime. Reentrant calls now execute against the explicitly requested context identity instead of reusing whichever sibling context was active at outer entry. This also adds focused regression coverage for both sync and async host-function reentrancy paths.

## Changes

### Reentrancy Runtime Bridge (`src/reentrance.rs`)

- Replaced the thread-local runtime -> stashed `Ctx` map with an active-runtime tracking set.
- Updated the reentrant fast path to synthesize a `Ctx` from `context.as_raw()` so nested evals run in the requested context.
- Kept the outer `Context::with` slow path + RAII cleanup so runtime lock/entry behavior remains unchanged.

### Isolation Regression Tests (`tests/test_reentrance.py`)

- Added a dedicated reentrance isolation test module with an explicit definition of "reentrant context".
- Added sync regressions proving `ctx_a` host functions that call `ctx_b.eval(...)` read/write `ctx_b`, not `ctx_a`.
- Added async regressions for the same invariant, including a nested reentrancy chain (`A -> B -> A`) under async host callbacks.
