### PR TITLE
feat(quickjs-rs): propagate host callback exceptions

### DIFF
--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -126,7 +126,7 @@ flowchart TD
 
 - **Fields**: `err_message`, `err_stack` in `quickjs_rs/context.py:Context._run_async_host_call`; rejection fields in `src/context.rs:QjsContext::reject_pending`.
 - **Storage**: Python exception objects and JS exception objects (`src/host_fn.rs:throw_host_error`).
-- **Access**: JS caller reading rejection reason through `src/context.rs:QjsContext::promise_result`; Python caller catching `quickjs_rs/errors.py:HostError`.
+- **Access**: JS caller reading rejection reason through `src/context.rs:QjsContext::promise_result` (sees only the sanitized payload); Python caller catching the original host exception when it bubbles out of `eval`/`eval_async` uncaught (re-raised by `quickjs_rs/context.py:Context._raise_classified`).
 - **Encryption**: none by default.
 - **Retention**: depends on caller log/error handling pipelines.
 - **Logging exposure**: high likelihood if caller logs JS/Python exceptions verbatim.
@@ -236,7 +236,7 @@ flowchart TD
 |----|-----------|----------------|--------|----------|----------|--------|------------|----------------|
 | T1 | DF7, DF8 | DC1 | Untrusted JS can invoke privileged registered callbacks, enabling Python-side side effects (file/network/process access) equivalent to code execution through callback capabilities. | TB3 | Critical | Accepted (by design) | Verified | `quickjs_rs/context.py:Context.register`, `src/context.rs:QjsContext::register_host_function`, `src/host_fn.rs:call_host_fn` |
 | T2 | DF1, DF4 | DC2, DC4 | CPU/memory denial-of-service when callers disable/raise limits (`memory_limit=None`, permissive timeout) while executing attacker-influenced scripts. | TB1 | High | Accepted with guardrails | Verified | `quickjs_rs/runtime.py:Runtime.__init__`, `src/runtime.rs:QjsRuntime::new`, `quickjs_rs/context.py:Context.eval`, `quickjs_rs/context.py:Context._eval_and_drive` |
-| T3 | DF9 | DC3 | Host exception messages and tracebacks can leak secrets/paths into JS-visible errors and upstream logs. | TB3 | High | Mitigated (sanitized JS HostError payload) | Verified | `quickjs_rs/context.py:Context._dispatch_host_call`, `quickjs_rs/context.py:Context._run_async_host_call`, `src/host_fn.rs:dispatch_async_host_fn` |
+| T3 | DF9 | DC3 | Host exception messages and tracebacks can leak secrets/paths into JS-visible errors and upstream logs. | TB3 | High | Mitigated for JS-visible surface (sanitized HostError payload); residual on Python-uncaught path | Verified | `quickjs_rs/context.py:Context._dispatch_host_call`, `quickjs_rs/context.py:Context._run_async_host_call`, `quickjs_rs/context.py:Context._raise_classified`, `src/host_fn.rs:dispatch_async_host_fn` |
 | T4 | DF1, DF4, DF11 | DC2, DC5 | Native engine vulnerability risk: attacker-controlled JS reaches embedded quickjs-ng execution path via `rquickjs`; upstream memory safety flaws could lead process compromise. | TB2, TB6 | Critical | Accepted (architectural) | Unverified | `src/context.rs:QjsContext::eval`, `src/context.rs:QjsContext::eval_module_async`, `src/runtime.rs:QjsRuntime::new` |
 | T5 | DF11 | DC5 | Build/runtime supply-chain compromise risk from external dependency code paths (`oxidase` transpilation and engine crates). | TB6 | High | Accepted | Likely | `src/modules.rs:maybe_strip_ts`, `src/runtime.rs:QjsRuntime::new` |
 | T6 | DF8 | DC1, DC5 | `pending_id` wraparound (`u32::wrapping_add`) can collide with unresolved entries, potentially misrouting async Promise settlements under extreme long-lived load. | TB5 | Medium | Mitigated (collision-safe allocator) | Verified | `src/host_fn.rs:dispatch_async_host_fn`, `src/host_fn.rs:find_available_pending_id`, `src/context.rs:QjsContext::resolve_pending` |
@@ -266,8 +266,8 @@ flowchart TD
 - **Flow**: DF9.
 - **Description**: callback exceptions include message/traceback that can surface to JS error objects and upstream service logs.
 - **Preconditions**: callback throws with sensitive content in message/stack; caller exposes error payload.
-- **Mitigations**: JS-visible host callback failures are sanitized to a stable `HostError` message (`"Host function failed"`) for both sync and async dispatch paths.
-- **Residual risk**: medium; original Python exception details remain available in Python (`HostError.__cause__`) and can still leak if callers log them verbatim.
+- **Mitigations**: JS-visible host callback failures are sanitized to a stable `JSError` (name `"HostError"`, message `"Host function failed"`, no stack) for both sync and async dispatch paths. JS `try/catch` and the eval result therefore never carry host exception content, so a model reading the eval tool's output never sees raw exception messages.
+- **Residual risk**: medium. When JS does not catch the rejection, the original host exception bubbles out of `eval`/`eval_async` as the underlying Python exception (`ValueError`, `RuntimeError`, etc.) — matching the leak surface of any non-quickjs Python tool that raises. The original message reaches caller-frame `try/except` and any default `log.exception()` in user code; caller-side log discipline (avoid logging exception messages verbatim from untrusted-callback code paths) is the residual control.
 
 #### T4: Native engine exploitability path
 
@@ -312,7 +312,7 @@ flowchart TD
 ### Threat Chain Analysis
 
 - **TC1 (T7 + T1)**: in pooled-runtime multi-tenant deployments, cross-tenant module poisoning can seed hostile helper code, then invoke privileged callback paths for lateral movement.
-- **TC2 (T3 + T1)**: callback abuse can still trigger sensitive failures; JS payloads are sanitized, but Python-side logging of underlying causes can still amplify exposure if not controlled.
+- **TC2 (T3 + T1)**: callback abuse can still trigger sensitive failures; JS-visible payloads are sanitized, but Python-side logging of the original exception (which bubbles out of `eval` on the uncaught path) can still amplify exposure if caller-side log discipline is not enforced.
 - **TC3 (T8 + T1)**: if reentrant context identity were to regress, callback-assisted cross-context eval could become a tenant-isolation bypass path on shared-runtime deployments.
 
 ---

--- a/.github/THREAT_MODEL.md
+++ b/.github/THREAT_MODEL.md
@@ -266,7 +266,7 @@ flowchart TD
 - **Flow**: DF9.
 - **Description**: callback exceptions include message/traceback that can surface to JS error objects and upstream service logs.
 - **Preconditions**: callback throws with sensitive content in message/stack; caller exposes error payload.
-- **Mitigations**: JS-visible host callback failures are sanitized to a stable `JSError` (name `"HostError"`, message `"Host function failed"`, no stack) for both sync and async dispatch paths. JS `try/catch` and the eval result therefore never carry host exception content, so a model reading the eval tool's output never sees raw exception messages.
+- **Mitigations**: JS-visible host callback failures are sanitized to a stable JS `Error` instance (`name = "HostError"`, `message = "Host function failed"`, no stack) for both sync and async dispatch paths. JS `try/catch` and the eval result therefore never carry host exception content, so a model reading the eval tool's output never sees raw exception messages.
 - **Residual risk**: medium. When JS does not catch the rejection, the original host exception bubbles out of `eval`/`eval_async` as the underlying Python exception (`ValueError`, `RuntimeError`, etc.) — matching the leak surface of any non-quickjs Python tool that raises. The original message reaches caller-frame `try/except` and any default `log.exception()` in user code; caller-side log discipline (avoid logging exception messages verbatim from untrusted-callback code paths) is the residual control.
 
 #### T4: Native engine exploitability path

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -281,10 +281,21 @@ class Context:
         JS-visible behavior is unaffected: this only runs when a
         rejection has bubbled past JS try/catch to the eval boundary.
         """
-        if name == "HostError" and self._last_host_exception is not None:
+        if (
+            name == "HostError"
+            and message == _HOST_ERROR_SANITIZED_MESSAGE
+            and self._last_host_exception is not None
+        ):
+            # The (name, message) shape matches what the bridge
+            # produces, so this rejection is from a host raise rather
+            # than a JS hand-thrown HostError-named error with a
+            # different message. ``from None`` so the caught
+            # _engine.JSError doesn't show up as ``__context__``
+            # ("During handling of the above exception") and leak
+            # QuickJS internals into the user's traceback.
             original = self._last_host_exception
             self._last_host_exception = None
-            raise original
+            raise original from None
         classified = self._classify_jserror(name, message, stack, deadline)
         raise classified from classified.__cause__
 

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -7,7 +7,7 @@ import inspect
 import time
 from collections.abc import Callable
 from types import TracebackType
-from typing import Any
+from typing import Any, NoReturn
 
 import quickjs_rs._engine as _engine
 from quickjs_rs.errors import (
@@ -92,9 +92,11 @@ class Context:
         # dispatcher looks up fn_id here.
         self._host_registry: dict[int, Callable[..., Any]] = {}
         self._next_fn_id: int = 1
-        # Host-exception side channel: when a host fn raises,
-        # the dispatcher stashes the Python exception here so eval's
-        # HostError catch can thread it via __cause__.
+        # Host-exception side channel: when a host fn raises, the
+        # dispatcher stashes the Python exception here so the eval
+        # boundary can re-raise the original (uncaught path) or thread
+        # it via __cause__ on a synthesized HostError (the rare path
+        # where JS hand-throws a HostError-named error).
         self._last_host_exception: BaseException | None = None
 
         # Async machinery. _eval_async_in_flight is the
@@ -187,8 +189,7 @@ class Context:
             name, message, stack = e.args
             if self._engine_ctx.take_sync_eval_hit_async_call():
                 raise sync_eval_handle_async_call_error() from None
-            classified = self._classify_jserror(name, message, stack, deadline)
-            raise classified from classified.__cause__
+            self._raise_classified(name, message, stack, deadline)
         except _engine.MarshalError as e:
             if self._engine_ctx.take_sync_eval_hit_async_call():
                 raise sync_eval_handle_async_call_error() from None
@@ -245,10 +246,7 @@ class Context:
             # downstream error the async-rejected promise produced.
             if self._engine_ctx.take_sync_eval_hit_async_call():
                 raise sync_eval_async_call_error() from None
-            classified = self._classify_jserror(name, message, stack, deadline)
-            # Preserve HostError.__cause__ that _classify_jserror
-            # just threaded from the side channel.
-            raise classified from classified.__cause__
+            self._raise_classified(name, message, stack, deadline)
         except _engine.MarshalError as e:
             if self._engine_ctx.take_sync_eval_hit_async_call():
                 raise sync_eval_async_call_error() from None
@@ -265,6 +263,31 @@ class Context:
             raise sync_eval_async_call_error()
         return result
 
+    def _raise_classified(
+        self,
+        name: str,
+        message: str,
+        stack: str | None,
+        deadline: float | None,
+    ) -> NoReturn:
+        """Raise the exception that should surface for this rejection.
+
+        For an uncaught host-callback rejection (name == "HostError"
+        with a stashed Python exception in the side channel), re-raise
+        the original Python exception so callers see the underlying
+        ValueError / RuntimeError / etc. directly. Otherwise classify
+        the JS error and raise the synthesized QuickJSError.
+
+        JS-visible behavior is unaffected: this only runs when a
+        rejection has bubbled past JS try/catch to the eval boundary.
+        """
+        if name == "HostError" and self._last_host_exception is not None:
+            original = self._last_host_exception
+            self._last_host_exception = None
+            raise original
+        classified = self._classify_jserror(name, message, stack, deadline)
+        raise classified from classified.__cause__
+
     def _classify_jserror(
         self,
         name: str,
@@ -277,7 +300,9 @@ class Context:
 
         - name == "HostError": threaded with __cause__ from
           self._last_host_exception so the original Python traceback
-          shows up for the user.
+          shows up for the user. (Only reached when JS code synthesizes
+          a HostError-named throw without an underlying host raise; an
+          actual host raise is unwrapped earlier in _raise_classified.)
         - name == "InternalError" with message "interrupted":
           TimeoutError. The runtime's only source of interrupts is
           the wall-clock deadline we install from eval entry; any
@@ -567,8 +592,7 @@ class Context:
                 )
         except _engine.JSError as e:
             name, message, stack = e.args
-            classified = self._classify_jserror(name, message, stack, deadline)
-            raise classified from classified.__cause__
+            self._raise_classified(name, message, stack, deadline)
         except _engine.MarshalError as e:
             raise MarshalError(str(e)) from None
         return Handle(self, inner)
@@ -744,8 +768,7 @@ class Context:
             message = str(message) if message is not None else ""
         if stack is not None and not isinstance(stack, str):
             stack = None
-        classified = self._classify_jserror(name, message, stack, deadline)
-        raise classified from classified.__cause__
+        self._raise_classified(name, message, stack, deadline)
 
     def _handle_name_is(self, reason: Handle, expected: str) -> bool:
         """Read the `.name` property off a JS exception Handle and
@@ -845,8 +868,9 @@ class Context:
             except BaseException as exc:
                 resolve_ok = False
                 self._last_host_exception = exc
-                # Preserve internals in Python (__cause__), but expose
-                # only a stable sanitized message over the JS boundary.
+                # Stable sanitized payload for the JS-visible rejection;
+                # the side-channel carries the original for re-raise at
+                # the eval boundary if JS doesn't catch.
                 err_message = _HOST_ERROR_SANITIZED_MESSAGE
                 err_stack = None
 
@@ -869,13 +893,12 @@ class Context:
         """fn_id → callable lookup and call. Invoked from the
         Rust trampoline with the GIL held.
 
-        On user-fn exception: stash the Python exception on the
-        side channel, re-raise as ``_engine.JSError(("HostError",
-        message, stack))`` so the Rust side throws a JS Error with
-        name="HostError". Context.eval catches the
-        ``_engine.JSError`` and promotes to the pure-Python
-        ``HostError`` with ``__cause__`` threaded from the side
-        channel.
+        On user-fn exception: stash the Python exception on the side
+        channel and re-raise a sanitized ``_engine.JSError("HostError",
+        "Host function failed", None)`` so JS try/catch sees only the
+        stable message. If the rejection bubbles out of eval uncaught,
+        ``_raise_classified`` consumes the side-channel and re-raises
+        the original Python exception.
         """
         fn = self._host_registry.get(fn_id)
         if fn is None:
@@ -888,6 +911,4 @@ class Context:
             return fn(*args)
         except BaseException as exc:
             self._last_host_exception = exc
-            # Preserve original exception in __cause__, while
-            # sanitizing the JS-visible HostError payload.
             raise _engine.JSError("HostError", _HOST_ERROR_SANITIZED_MESSAGE, None) from None

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -153,9 +153,7 @@ async def test_eval_handle_async_returns_handle() -> None:
 
 async def test_eval_async_propagates_js_rejection() -> None:
     """An async host fn that raises → rejected Promise →
-    HostError surfaces from eval_async via routing."""
-    from quickjs_rs import HostError
-
+    original exception bubbles out of eval_async uncaught."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
 
@@ -165,10 +163,8 @@ async def test_eval_async_propagates_js_rejection() -> None:
 
             ctx.register("fail", fail)
 
-            with pytest.raises(HostError) as excinfo:
+            with pytest.raises(ValueError, match="from async host"):
                 await ctx.eval_async("await fail()")
-            assert excinfo.value.message == "Host function failed"
-            assert isinstance(excinfo.value.__cause__, ValueError)
 
 
 async def test_handle_await_promise_happy_path() -> None:

--- a/tests/test_async_host_functions.py
+++ b/tests/test_async_host_functions.py
@@ -367,16 +367,15 @@ async def test_sync_eval_js_try_catch_still_raises_concurrent_eval_error() -> No
                 ctx.eval("try { slow(); 'unreachable' } catch (e) { e.name }")
 
 
-async def test_async_host_function_raises_surfaces_hosterror() -> None:
+async def test_async_host_function_raises_propagates_original() -> None:
     """async path: a non-cancellation exception in an async host
-    function surfaces as HostError on the eval_async caller with the
-    original Python exception threaded via __cause__.
+    function bubbles out of eval_async as the original Python
+    exception when JS doesn't catch.
 
-    Distinct from the cancellation path — this is the
-    ordinary raise, not a CancelledError. Exercises the dispatcher's
-    encode-as-HostError-record branch in _run_async_host_call."""
-    from quickjs_rs import HostError
-
+    Distinct from the cancellation path — this is the ordinary raise,
+    not a CancelledError. Exercises the dispatcher's encode-as-
+    HostError-record branch in _run_async_host_call together with
+    Context._raise_classified's original-exception promotion."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
 
@@ -389,10 +388,8 @@ async def test_async_host_function_raises_surfaces_hosterror() -> None:
 
             ctx.register("broken", broken)
 
-            with pytest.raises(HostError) as excinfo:
+            with pytest.raises(CustomError, match="specific failure mode"):
                 await ctx.eval_async("await broken()")
-            assert excinfo.value.message == "Host function failed"
-            assert isinstance(excinfo.value.__cause__, CustomError)
 
 
 async def test_handle_call_async_host_fn_raises_concurrent_eval_error() -> None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -17,23 +17,23 @@ def test_js_thrown_error_surfaces_name_message_stack() -> None:
             assert excinfo.value.stack is not None
 
 
-def test_host_error_cause_points_at_original_python_exception() -> None:
+def test_host_exception_bubbles_out_as_original() -> None:
+    """Uncaught host raise → original Python exception escapes ctx.eval."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
             @ctx.function
             def fail() -> None:
                 raise KeyError("missing")
 
-            with pytest.raises(HostError) as excinfo:
+            with pytest.raises(KeyError, match="missing"):
                 ctx.eval("fail()")
-            assert isinstance(excinfo.value.__cause__, KeyError)
 
 
-def test_host_error_cause_is_cleared_between_evals() -> None:
-    """A successful host-fn call after a failing one must not inherit the
-    previous __cause__. If the bridge's side-channel isn't cleared on
-    consumption, a subsequent unrelated JSError could surface with a
-    bogus Python traceback attached.
+def test_host_exception_side_channel_cleared_between_evals() -> None:
+    """A first eval that raises a host exception must not poison a
+    later, unrelated eval. The bridge clears _last_host_exception at
+    each eval entry so a JS-thrown TypeError after an earlier host raise
+    surfaces as a plain JSError with no Python-side cause attached.
     """
     with Runtime() as rt:
         with rt.new_context() as ctx:
@@ -41,10 +41,9 @@ def test_host_error_cause_is_cleared_between_evals() -> None:
             def fail() -> None:
                 raise KeyError("first call")
 
-            # First eval raises HostError with a cause.
-            with pytest.raises(HostError) as first:
+            # First eval bubbles out the original KeyError.
+            with pytest.raises(KeyError, match="first call"):
                 ctx.eval("fail()")
-            assert isinstance(first.value.__cause__, KeyError)
 
             # A plain JS-thrown error that isn't HostError-named should
             # raise as JSError with no Python-side cause.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -81,6 +81,30 @@ def test_swallowed_host_raise_does_not_leak_cause_into_later_eval() -> None:
             assert excinfo.value.__cause__ is None
 
 
+def test_within_eval_synthesized_hosterror_not_misattributed_to_swallowed_raise() -> None:
+    """Same eval: host A raises and JS catches it; JS then hand-throws an
+    error with name='HostError'. The synthesized throw must surface as
+    HostError (not as the swallowed Python exception). The bridge's
+    re-raise unwrap is keyed on the (name, message, stack) shape that
+    only the bridge produces, so a JS-synthesized HostError-named throw
+    with a custom message and a JS stack does not consume the side
+    channel.
+    """
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+            @ctx.function
+            def swallowed() -> None:
+                raise RuntimeError("never see this")
+
+            with pytest.raises(HostError) as excinfo:
+                ctx.eval(
+                    "try { swallowed(); } catch (e) {}"
+                    " const fake = new Error('synth'); fake.name = 'HostError'; throw fake;"
+                )
+            assert excinfo.value.message == "synth"
+            assert not isinstance(excinfo.value, RuntimeError)
+
+
 def test_js_catches_hosterror_and_reads_name_and_message() -> None:
     """The HostError the host throws must be catchable from JS with its
     name and message intact. ."""

--- a/tests/test_host_functions.py
+++ b/tests/test_host_functions.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from quickjs_rs import HostError, Runtime
+import pytest
+
+from quickjs_rs import Runtime
 
 
 def test_reentrant_eval_from_host_function() -> None:
@@ -59,9 +61,10 @@ def test_host_function_args_are_copied_before_dispatch() -> None:
             assert seen == ["alpha", "beta"]
 
 
-def test_host_function_exception_surfaces_as_hosterror() -> None:
-    """Python exception out of a registered host function round-trips as
-    HostError when it escapes back through ctx.eval. ."""
+def test_host_function_exception_propagates_original() -> None:
+    """An uncaught host-function exception bubbles out of ctx.eval as
+    the original Python exception. JS-visible try/catch still sees
+    only the sanitized HostError name/message."""
     with Runtime() as rt:
         with rt.new_context() as ctx:
 
@@ -69,12 +72,8 @@ def test_host_function_exception_surfaces_as_hosterror() -> None:
             def explode() -> None:
                 raise RuntimeError("bang")
 
-            try:
+            with pytest.raises(RuntimeError, match="bang"):
                 ctx.eval("explode()")
-            except HostError as exc:
-                assert exc.message == "Host function failed"
-            else:
-                raise AssertionError("expected HostError")
 
 
 def test_register_preserves_callable_identity() -> None:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -14,7 +14,6 @@ import pytest
 from quickjs_rs import (
     ConcurrentEvalError,
     DeadlockError,
-    HostError,
     InvalidHandleError,  # noqa: F401 — exercised once handles land
     JSError,
     MarshalError,  # noqa: F401 — exercised when handle marshaling lands
@@ -79,18 +78,18 @@ def test_smoke_primitives() -> None:
             ctx.register("say_hi", lambda who: f"hi {who}")
             assert ctx.eval("say_hi('world')") == "hi world"
 
-            # Host exception propagates out as HostError with __cause__
-            # threaded back to the original Python exception.
+            # Uncaught host exception bubbles out of ctx.eval as the
+            # original Python exception.
             @ctx.function
             def boom() -> None:
                 raise ValueError("from python")
 
-            with pytest.raises(HostError) as excinfo:
+            with pytest.raises(ValueError, match="from python"):
                 ctx.eval("boom()")
-            assert isinstance(excinfo.value.__cause__, ValueError)
 
-            # JS-side visibility: a try/catch inside JS sees the error's
-            # name and message and can round-trip them back as a string.
+            # JS-side visibility: a try/catch inside JS sees only the
+            # sanitized HostError name/message — the T3 mitigation
+            # surface, unaffected by Python-side propagation.
             assert (
                 ctx.eval("try { boom(); 'unreachable'; } catch (e) { e.name + ': ' + e.message }")
                 == "HostError: Host function failed"
@@ -204,16 +203,16 @@ def test_acceptance() -> None:
             assert excinfo.value.message == "bad thing"
             assert excinfo.value.stack is not None
 
-            # Host exception → JS → Python
+            # Host exception → original Python exception bubbles out of eval
             @ctx.function
             def boom() -> None:
                 raise ValueError("from python")
 
-            with pytest.raises(HostError) as excinfo_h:
+            with pytest.raises(ValueError, match="from python"):
                 ctx.eval("boom()")
-            assert isinstance(excinfo_h.value.__cause__, ValueError)
 
-            # JS catching host error
+            # JS catching host error: only the sanitized name/message
+            # are visible to JS.
             assert (
                 ctx.eval(
                     """


### PR DESCRIPTION
JS-visible error messages (e.g., as try/caught) stay sanitized.