### PR TITLE
fix(quickjs-rs): exclude async host wait time from eval_async deadlines

### DIFF
--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -103,13 +103,15 @@ class Context:
         # concurrent-eval guard — only one eval_async / await_promise
         # at a time per context. _cumulative_deadline is the rolling
         # budget shared across eval_async calls; per-call timeout=
-        # overrides for one call only. _pending_tasks tracks the
-        # asyncio tasks we've spawned for async host calls so the
-        # driving loop knows when to wait vs raise DeadlockError.
-        # _pending_completed is the wake-up event the driving loop
-        # waits on between tasks. _active_task_group is set during
-        # _run_inside_task_group so the async host dispatcher schedules
-        # into it instead of loop.create_task.
+        # overrides for one call only. The cumulative budget tracks
+        # JS-execution wall time only — time spent awaiting async
+        # host calls is reclaimed by the driving loop. _pending_tasks
+        # tracks the asyncio tasks we've spawned for async host calls
+        # so the driving loop knows when to wait vs raise
+        # DeadlockError. _pending_completed is the wake-up event the
+        # driving loop waits on between tasks. _active_task_group is
+        # set during _run_inside_task_group so the async host
+        # dispatcher schedules into it instead of loop.create_task.
         self._cumulative_deadline = time.monotonic() + timeout
         self._eval_async_in_flight = False
         self._pending_tasks: dict[int, asyncio.Task[Any]] = {}
@@ -443,6 +445,15 @@ class Context:
           To surface a value, set ``globalThis.result = ...`` in the
           module and read it with a sync ``ctx.eval("result")``.
 
+        Timeout semantics: ``timeout`` (and the context's cumulative
+        budget when ``timeout`` is omitted) governs JS-execution wall
+        time only. Time the driving loop spends awaiting an
+        asynchronous host call to settle is reclaimed from both
+        budgets, so a host that runs longer than ``timeout`` does
+        not by itself trip the deadline. Hosts are responsible for
+        bounding their own work; runaway JS bytecode between host
+        calls still trips the interrupt handler at ``timeout``.
+
         Cancellation: if the enclosing asyncio task is cancelled,
         the driving loop rejects in-flight host-call Promises with a
         HostCancellationError and runs one final pending-jobs drain
@@ -488,6 +499,11 @@ class Context:
     ) -> Handle:
         """Same driving flow as :meth:`eval_async`, but return the
         settled value as a :class:`Handle` rather than marshaling.
+
+        Timeout semantics match :meth:`eval_async`: ``timeout``
+        covers JS-execution wall time only; time spent awaiting
+        async host calls is reclaimed from both the per-call
+        deadline and the context's cumulative budget.
 
         ``module=True``: returns a Handle to ``undefined`` (ES
         modules complete with undefined). The module's exports are
@@ -714,8 +730,18 @@ class Context:
                             assert event is not None, (
                                 "pending task present but completion event is None"
                             )
+                            # timeout covers JS-execution time only —
+                            # reclaim the host-await wall-clock from both
+                            # the per-call deadline (interrupt handler
+                            # re-reads when JS resumes) and the cumulative
+                            # budget.
+                            wait_start = time.monotonic()
                             await event.wait()
                             event.clear()
+                            elapsed_wait = time.monotonic() - wait_start
+                            deadline += elapsed_wait
+                            self._cumulative_deadline += elapsed_wait
+                            self._runtime._deadline = deadline
 
                             if time.monotonic() >= deadline:
                                 raise TimeoutError("eval_async exceeded its deadline")

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -734,14 +734,17 @@ class Context:
                             # reclaim the host-await wall-clock from both
                             # the per-call deadline (interrupt handler
                             # re-reads when JS resumes) and the cumulative
-                            # budget.
+                            # budget. try/finally so a CancelledError
+                            # mid-wait still reclaims its share.
                             wait_start = time.monotonic()
-                            await event.wait()
+                            try:
+                                await event.wait()
+                            finally:
+                                elapsed_wait = time.monotonic() - wait_start
+                                deadline += elapsed_wait
+                                self._cumulative_deadline += elapsed_wait
+                                self._runtime._deadline = deadline
                             event.clear()
-                            elapsed_wait = time.monotonic() - wait_start
-                            deadline += elapsed_wait
-                            self._cumulative_deadline += elapsed_wait
-                            self._runtime._deadline = deadline
 
                             if time.monotonic() >= deadline:
                                 raise TimeoutError("eval_async exceeded its deadline")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -294,23 +294,23 @@ async def test_handle_await_promise_concurrent_eval_raises() -> None:
                 p.dispose()
 
 
-async def test_eval_async_per_call_timeout_override() -> None:
-    """timeout= kwarg on eval_async overrides the cumulative
-    budget for that call. With the override set short, a slow async
-    host call should abort with TimeoutError."""
-    from quickjs_rs import TimeoutError as _TimeoutError
-
+async def test_per_call_timeout_excludes_host_call_time() -> None:
+    """``timeout`` on eval_async governs JS-execution wall time only.
+    A host whose ``await asyncio.sleep`` runs longer than the
+    per-call timeout does NOT trip the deadline — the driving loop
+    reclaims the wait time. Hosts are responsible for bounding their
+    own work."""
     with Runtime() as rt:
         with rt.new_context(timeout=60.0) as ctx:
 
-            async def very_slow() -> str:
-                await asyncio.sleep(5.0)  # way longer than override
+            async def slow() -> str:
+                # Comfortably longer than the per-call timeout below.
+                await asyncio.sleep(0.2)
                 return "done"
 
-            ctx.register("very_slow", very_slow)
+            ctx.register("slow", slow)
 
-            with pytest.raises(_TimeoutError):
-                await ctx.eval_async("await very_slow()", timeout=0.05)
+            assert await ctx.eval_async("await slow()", timeout=0.05) == "done"
 
 
 async def test_promise_chain_resolves_synchronously() -> None:
@@ -345,51 +345,54 @@ async def test_throw_in_then_callback_propagates_as_js_error() -> None:
             assert "boom" in exc_info.value.message
 
 
-async def test_cumulative_timeout_two_calls_within_budget() -> None:
-    """the cumulative budget is shared across eval_async calls
-    on the same context. Two short calls whose combined wall-clock
-    stays under the budget should both succeed."""
+async def test_cumulative_budget_excludes_host_call_time() -> None:
+    """The cumulative budget tracks JS-execution wall time only.
+    Two eval_async calls whose host awaits each individually exceed
+    the budget should both succeed, because host wait time is
+    reclaimed from the cumulative deadline as well as the per-call
+    one."""
     with Runtime() as rt:
-        with rt.new_context(timeout=1.0) as ctx:
-
-            async def tiny() -> str:
-                await asyncio.sleep(0.01)
-                return "ok"
-
-            ctx.register("tiny", tiny)
-
-            assert await ctx.eval_async("await tiny()") == "ok"
-            assert await ctx.eval_async("await tiny()") == "ok"
-
-
-async def test_cumulative_timeout_exceeded_on_later_call() -> None:
-    """once the cumulative budget is exhausted, subsequent
-    eval_async calls on the context raise TimeoutError — even a
-    trivial 1+1 that would otherwise be instant, because the
-    deadline check fires at interrupt-poll time regardless of what
-    the call is doing.
-
-    This is the shape that makes "long-running agent loop with a
-    total time budget" work cleanly: turn 1-5 consume their time,
-    turn 6 bounces with TimeoutError so the caller knows the
-    budget is done."""
-    from quickjs_rs import TimeoutError as _TimeoutError
-
-    # Short budget so the test wall-clock is short.
-    with Runtime() as rt:
+        # Tight budget; both host sleeps below comfortably exceed it.
         with rt.new_context(timeout=0.05) as ctx:
 
-            async def consumer() -> None:
-                await asyncio.sleep(0.1)  # eat the whole budget
+            async def slow() -> str:
+                await asyncio.sleep(0.1)
+                return "ok"
 
-            ctx.register("consumer", consumer)
+            ctx.register("slow", slow)
 
-            # First call exceeds the budget on its own.
+            assert await ctx.eval_async("await slow()") == "ok"
+            assert await ctx.eval_async("await slow()") == "ok"
+
+
+async def test_cumulative_budget_still_trips_on_js_time() -> None:
+    """Host time is reclaimed, but pure JS execution still counts.
+    A tight JS loop dispatched via eval_async with no host calls
+    must trip the cumulative budget via the interrupt handler."""
+    from quickjs_rs import TimeoutError as _TimeoutError
+
+    with Runtime() as rt:
+        with rt.new_context(timeout=0.1) as ctx:
             with pytest.raises(_TimeoutError):
-                await ctx.eval_async("await consumer()")
+                await ctx.eval_async("while (true) {}", module=False)
 
-            # Second call — even 1+1 — should still raise because the
-            # budget counter is past the deadline.
+
+async def test_cumulative_budget_drained_by_wall_time_outside_eval() -> None:
+    """Host-wait reclamation only fires inside the driving loop.
+    Wall-clock that elapses outside any eval still drains the
+    cumulative budget; the next eval bounces with TimeoutError.
+
+    Pinned because the natural read of "JS-only timeout" might
+    suggest the cumulative deadline never advances when no JS is
+    running. It does — the budget is set at context construction
+    and is monotonic-time absolute. Only async-host-await time
+    *during* an eval is reclaimed."""
+    from quickjs_rs import TimeoutError as _TimeoutError
+
+    with Runtime() as rt:
+        with rt.new_context(timeout=0.05) as ctx:
+            # Idle past the cumulative deadline outside any eval.
+            await asyncio.sleep(0.1)
             with pytest.raises(_TimeoutError):
                 await ctx.eval_async("1 + 1", module=False)
 


### PR DESCRIPTION
Context.eval_async's `timeout=` (and the context's cumulative budget) includes time spent awaiting async host calls (e.g., from foreign functions / langchain-quickjs REPL tools).

Here we change timeout to govern JS-execution wall time only. The driving loop reclaims time spent in `await event.wait()` from both the per-call deadline and _cumulative_deadline, and reinstalls the advanced value on _runtime._deadline so the interrupt handler honors it when JS resumes.

Hosts are responsible for bounding their own work; runaway JS still trips the interrupt at timeout. Wall time outside any eval still drains the cumulative budget.