### PR TITLE
fix(timeout): make async timeouts per-call by default

### DIFF
--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -101,18 +101,13 @@ class Context:
 
         # Async machinery. _eval_async_in_flight is the
         # concurrent-eval guard — only one eval_async / await_promise
-        # at a time per context. _cumulative_deadline is the rolling
-        # budget shared across eval_async calls; per-call timeout=
-        # overrides for one call only. The cumulative budget tracks
-        # JS-execution wall time only — time spent awaiting async
-        # host calls is reclaimed by the driving loop. _pending_tasks
-        # tracks the asyncio tasks we've spawned for async host calls
-        # so the driving loop knows when to wait vs raise
-        # DeadlockError. _pending_completed is the wake-up event the
-        # driving loop waits on between tasks. _active_task_group is
-        # set during _run_inside_task_group so the async host
-        # dispatcher schedules into it instead of loop.create_task.
-        self._cumulative_deadline = time.monotonic() + timeout
+        # at a time per context. _pending_tasks tracks the asyncio
+        # tasks we've spawned for async host calls so the driving loop
+        # knows when to wait vs raise DeadlockError.
+        # _pending_completed is the wake-up event the driving loop
+        # waits on between tasks. _active_task_group is set during
+        # _run_inside_task_group so the async host dispatcher schedules
+        # into it instead of loop.create_task.
         self._eval_async_in_flight = False
         self._pending_tasks: dict[int, asyncio.Task[Any]] = {}
         self._pending_completed: asyncio.Event | None = None
@@ -445,14 +440,11 @@ class Context:
           To surface a value, set ``globalThis.result = ...`` in the
           module and read it with a sync ``ctx.eval("result")``.
 
-        Timeout semantics: ``timeout`` (and the context's cumulative
-        budget when ``timeout`` is omitted) governs JS-execution wall
-        time only. Time the driving loop spends awaiting an
-        asynchronous host call to settle is reclaimed from both
-        budgets, so a host that runs longer than ``timeout`` does
-        not by itself trip the deadline. Hosts are responsible for
-        bounding their own work; runaway JS bytecode between host
-        calls still trips the interrupt handler at ``timeout``.
+        Timeout accounting excludes wall-clock spent awaiting async
+        host calls; only JS execution time counts against the deadline.
+
+        Timeout semantics: ``timeout`` overrides this call's deadline.
+        If omitted, the context default timeout is used for this call.
 
         Cancellation: if the enclosing asyncio task is cancelled,
         the driving loop rejects in-flight host-call Promises with a
@@ -501,9 +493,8 @@ class Context:
         settled value as a :class:`Handle` rather than marshaling.
 
         Timeout semantics match :meth:`eval_async`: ``timeout``
-        covers JS-execution wall time only; time spent awaiting
-        async host calls is reclaimed from both the per-call
-        deadline and the context's cumulative budget.
+        overrides this call's deadline, and the context default is
+        used when omitted.
 
         ``module=True``: returns a Handle to ``undefined`` (ES
         modules complete with undefined). The module's exports are
@@ -552,23 +543,11 @@ class Context:
                 "workloads"
             )
         self._last_host_exception = None
-        # Timeout semantics: per-call override or cumulative.
+        # Timeout semantics: per-call override or context default.
         if timeout is not None:
             deadline = time.monotonic() + timeout
         else:
-            deadline = self._cumulative_deadline
-            # Pre-check: the interrupt handler only fires during
-            # bytecode execution; a near-instant eval that completes
-            # before the next interrupt check would silently succeed
-            # past an expired budget. Raising up front matches
-            # the tripwire test_sync_eval_does_not_decrement_
-            # cumulative_budget's companion on the async side.
-            if time.monotonic() >= deadline:
-                raise TimeoutError(
-                    "eval_async's cumulative timeout budget has "
-                    "elapsed; create a new context or pass timeout= "
-                    "to this call for a fresh budget"
-                )
+            deadline = time.monotonic() + self._timeout
 
         self._eval_async_in_flight = True
         self._runtime._deadline = deadline
@@ -730,19 +709,12 @@ class Context:
                             assert event is not None, (
                                 "pending task present but completion event is None"
                             )
-                            # timeout covers JS-execution time only —
-                            # reclaim the host-await wall-clock from both
-                            # the per-call deadline (interrupt handler
-                            # re-reads when JS resumes) and the cumulative
-                            # budget. try/finally so a CancelledError
-                            # mid-wait still reclaims its share.
                             wait_start = time.monotonic()
+                            self._runtime._deadline = None
                             try:
                                 await event.wait()
                             finally:
-                                elapsed_wait = time.monotonic() - wait_start
-                                deadline += elapsed_wait
-                                self._cumulative_deadline += elapsed_wait
+                                deadline += time.monotonic() - wait_start
                                 self._runtime._deadline = deadline
                             event.clear()
 

--- a/quickjs_rs/handle.py
+++ b/quickjs_rs/handle.py
@@ -270,8 +270,9 @@ class Handle:
 
         Respects the enclosing cancel scope (cancellation in the
         driving task cascades here). Uses the owning Context's
-        cumulative eval_async budget unless ``timeout=`` is passed,
-        in which case that value applies for this call only.
+        per-call timeout by default (same semantics as
+        ``Context.eval_async``); ``timeout=`` overrides it for this
+        call only.
 
         Honours the concurrent-eval rule: if an ``eval_async``
         or another ``await_promise`` is in flight on the same
@@ -298,7 +299,7 @@ class Handle:
         if timeout is not None:
             deadline = _time.monotonic() + timeout
         else:
-            deadline = ctx._cumulative_deadline
+            deadline = _time.monotonic() + ctx._timeout
 
         ctx._eval_async_in_flight = True
         ctx._runtime._deadline = deadline

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -295,11 +295,8 @@ async def test_handle_await_promise_concurrent_eval_raises() -> None:
 
 
 async def test_per_call_timeout_excludes_host_call_time() -> None:
-    """``timeout`` on eval_async governs JS-execution wall time only.
-    A host whose ``await asyncio.sleep`` runs longer than the
-    per-call timeout does NOT trip the deadline — the driving loop
-    reclaims the wait time. Hosts are responsible for bounding their
-    own work."""
+    """Host-function await time is excluded from eval_async timeout
+    accounting."""
     with Runtime() as rt:
         with rt.new_context(timeout=60.0) as ctx:
 
@@ -346,23 +343,20 @@ async def test_throw_in_then_callback_propagates_as_js_error() -> None:
 
 
 async def test_cumulative_budget_excludes_host_call_time() -> None:
-    """The cumulative budget tracks JS-execution wall time only.
-    Two eval_async calls whose host awaits each individually exceed
-    the budget should both succeed, because host wait time is
-    reclaimed from the cumulative deadline as well as the per-call
-    one."""
+    """Two eval_async calls use independent per-eval timeout budgets."""
     with Runtime() as rt:
-        # Tight budget; both host sleeps below comfortably exceed it.
+        # Combined wall time exceeds one timeout window, but each call
+        # gets a fresh budget.
         with rt.new_context(timeout=0.05) as ctx:
 
-            async def slow() -> str:
-                await asyncio.sleep(0.1)
+            async def tiny() -> str:
+                await asyncio.sleep(0.03)
                 return "ok"
 
-            ctx.register("slow", slow)
+            ctx.register("tiny", tiny)
 
-            assert await ctx.eval_async("await slow()") == "ok"
-            assert await ctx.eval_async("await slow()") == "ok"
+            assert await ctx.eval_async("await tiny()") == "ok"
+            assert await ctx.eval_async("await tiny()") == "ok"
 
 
 async def test_cumulative_budget_still_trips_on_js_time() -> None:
@@ -378,59 +372,33 @@ async def test_cumulative_budget_still_trips_on_js_time() -> None:
 
 
 async def test_cumulative_budget_drained_by_wall_time_outside_eval() -> None:
-    """Host-wait reclamation only fires inside the driving loop.
-    Wall-clock that elapses outside any eval still drains the
-    cumulative budget; the next eval bounces with TimeoutError.
-
-    Pinned because the natural read of "JS-only timeout" might
-    suggest the cumulative deadline never advances when no JS is
-    running. It does — the budget is set at context construction
-    and is monotonic-time absolute. Only async-host-await time
-    *during* an eval is reclaimed."""
-    from quickjs_rs import TimeoutError as _TimeoutError
+    """Wall-clock outside eval_async should not consume later
+    timeout budget."""
 
     with Runtime() as rt:
         with rt.new_context(timeout=0.05) as ctx:
-            # Idle past the cumulative deadline outside any eval.
+            # Idle well past timeout before starting eval.
             await asyncio.sleep(0.1)
-            with pytest.raises(_TimeoutError):
-                await ctx.eval_async("1 + 1", module=False)
+            assert await ctx.eval_async("1 + 1", module=False) == 2
 
 
 async def test_per_call_timeout_override_lifts_above_cumulative() -> None:
-    """timeout= kwarg on eval_async replaces the cumulative
-    deadline for that call only. A call that would otherwise bounce
-    on the depleted cumulative budget can still succeed with an
-    explicit override."""
+    """timeout= kwarg on eval_async overrides the default timeout for
+    that call only."""
+    from quickjs_rs import TimeoutError as _TimeoutError
+
     with Runtime() as rt:
-        # Tiny cumulative budget so it's easy to exhaust.
         with rt.new_context(timeout=0.01) as ctx:
-            # Sleep to push past the cumulative deadline.
-            await asyncio.sleep(0.05)
-
-            # Without override: cumulative exhausted, should fail.
-            from quickjs_rs import TimeoutError as _TimeoutError
-
+            # Default timeout is too short for pure JS runaway compute.
             with pytest.raises(_TimeoutError):
-                await ctx.eval_async("1 + 1", module=False)
+                await ctx.eval_async("while(true){}", module=False)
 
-            # With override: a fresh 1-second budget for this call
-            # only. The cumulative deadline is irrelevant.
-            assert await ctx.eval_async("1 + 1", module=False, timeout=1.0) == 2
+            # Override extends this call only.
+            assert await ctx.eval_async("1 + 1", module=False, timeout=0.2) == 2
 
 
 def test_sync_eval_does_not_decrement_cumulative_budget() -> None:
-    """The cumulative budget applies
-    only to eval_async. Sync eval has its own per-call timeout and
-    doesn't consume the async budget. If a future refactor
-    accidentally unifies the sync/async deadline tracking (e.g. by
-    sharing a single _active_deadline on the bridge), a subsequent
-    eval_async would see a deadline that's already passed because
-    the sync eval's deadline was in monotonic-time past.
-
-    Verifies: sync ctx.eval runs freely (per-call deadline), then
-    eval_async still has its full cumulative budget available.
-    """
+    """Sync eval and eval_async each use per-call timeout budgets."""
     import time as _time
 
     async def body() -> None:
@@ -446,16 +414,15 @@ def test_sync_eval_does_not_decrement_cumulative_budget() -> None:
                 # trying to prove.
                 assert _time.monotonic() - start < 0.5
 
-                # Now eval_async. The cumulative budget started at
-                # context-creation time; sync eval shouldn't have
-                # consumed it. The async call has ~1.0s still.
+                # Prior sync evals should not affect this call's
+                # timeout budget.
                 async def sleepy() -> str:
                     await asyncio.sleep(0.05)
                     return "ok"
 
                 ctx.register("sleepy", sleepy)
                 assert await ctx.eval_async("await sleepy()") == "ok"
-                # If sync eval decremented the budget incorrectly,
-                # the above would have raised TimeoutError.
+                # If sync eval consumed async timeout budget, this
+                # could have raised TimeoutError.
 
     asyncio.run(body())


### PR DESCRIPTION
## Summary

This change makes async timeout behavior per-eval by default instead of using a context-level cumulative timeout budget. `Context.eval_async(...)` and `Handle.await_promise(...)` now each start with a fresh deadline based on the context timeout unless an explicit `timeout=` override is provided. This aligns async timeout behavior with sync eval's per-call model.

## Changes

### `quickjs_rs`

- Updated async deadline setup in `quickjs_rs/context.py`:
  - Removed cumulative-budget state from context initialization.
  - Switched default `eval_async` deadline calculation to `time.monotonic() + self._timeout`.
  - Removed the cumulative-budget exhaustion pre-check path.
- Updated `Handle.await_promise()` in `quickjs_rs/handle.py`:
  - Default deadline now uses a fresh per-call timeout (`time.monotonic() + ctx._timeout`).
  - Docstring updated to reflect per-call semantics.

### Tests

- Reworked timeout tests in `tests/test_async.py` to validate per-call behavior:
  - Replaced cumulative-budget assertions with per-call assertions.
  - Added coverage that timed-out calls do not poison subsequent calls.
  - Added coverage that timeout starts at call time and that `timeout=` can extend default behavior.
