### PR TITLE
fix(snapshot): preserve top-level-await eval_async bindings

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -12,12 +12,22 @@ use oxc_span::SourceType;
 ///
 /// Returns `None` on parser error (caller should skip registry update).
 pub(crate) fn extract_top_level_declared_names(source: &str, module: bool) -> Option<Vec<String>> {
+    let source_type = if module { SourceType::mjs() } else { SourceType::cjs() };
+    if let Some(names) = parse_declared_names(source, source_type) {
+        return Some(names);
+    }
+
+    // Script-mode eval_async allows top-level await via JS_EVAL_FLAG_ASYNC.
+    // The parser only accepts top-level await in module mode, so fall back
+    // to a module parse solely for declaration extraction.
+    if module {
+        return None;
+    }
+    parse_declared_names(source, SourceType::mjs())
+}
+
+fn parse_declared_names(source: &str, source_type: SourceType) -> Option<Vec<String>> {
     let allocator = Allocator::default();
-    let source_type = if module {
-        SourceType::mjs()
-    } else {
-        SourceType::cjs()
-    };
     let parsed = Parser::new(&allocator, source, source_type).parse();
     if parsed.panicked || !parsed.errors.is_empty() {
         return None;
@@ -109,4 +119,15 @@ mod tests {
     fn parser_error_returns_none() {
         assert!(extract_top_level_declared_names("const =", false).is_none());
     }
+
+    #[test]
+    fn extracts_top_level_await_script_declarations() {
+        let got = extract_top_level_declared_names(
+            "await Promise.resolve('x'); const story = 'hi'",
+            false,
+        )
+        .unwrap();
+        assert_eq!(got, vec!["story"]);
+    }
+
 }

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -230,6 +230,36 @@ async def test_create_snapshot_async_roundtrip() -> None:
             assert ctx2.eval("a === b") is True
 
 
+@pytest.mark.parametrize(
+    ("setup", "probe"),
+    [
+        ("const story = 'hi'", "story"),
+        ("const story = await Promise.resolve('hi')", "story"),
+        ("await Promise.resolve('x'); const story = 'hi'", "story"),
+        ("let story", "story = await Promise.resolve('hi'); story"),
+    ],
+    ids=[
+        "non-await-declaration",
+        "top-level-await-declaration",
+        "await-before-declaration",
+        "predeclared-then-await-assign",
+    ],
+)
+async def test_snapshot_roundtrip_preserves_eval_async_bindings(
+    setup: str, probe: str
+) -> None:
+    with Runtime(memory_limit=64 * 1024 * 1024) as runtime:
+        with runtime.new_context(timeout=5.0) as ctx:
+            await ctx.eval_async(setup, timeout=5.0)
+            before = await ctx.eval_async(probe, timeout=5.0)
+            payload = ctx.create_snapshot().to_bytes()
+        with runtime.new_context(timeout=5.0) as ctx2:
+            runtime.restore_snapshot(Snapshot.from_bytes(payload), ctx2, inject_globals=True)
+            after = await ctx2.eval_async(probe, timeout=5.0)
+    assert before == "hi"
+    assert after == "hi"
+
+
 async def test_create_snapshot_async_missing_name_tombstone() -> None:
     with Runtime() as rt:
         with rt.new_context() as ctx:


### PR DESCRIPTION
## Summary

Fix snapshot/restore persistence for bindings declared in `eval_async` script code that contains top-level `await`.

Snapshot name tracking previously parsed `module=False` eval source only as script/CJS, which can reject top-level `await` and skip declaration registration. This change adds a parser fallback so those declarations are still tracked and restored, while keeping existing behavior for standard script and module paths.

## Changes

### Runtime parsing and snapshot name tracking (`src/ast.rs`)

- Refactored top-level declaration extraction to parse with the requested source type first, then (for script mode only) retry with module parsing when script parsing fails.
- Added a dedicated parser helper to centralize declaration collection.
- Added a Rust unit test covering top-level-`await` script declaration extraction.

### Snapshot regression coverage (`tests/test_snapshot.py`)

- Added a parametrized async snapshot roundtrip regression test for four declaration patterns:
  - non-await declaration (control)
  - declaration with top-level `await`
  - `await` before declaration
  - predeclared binding with awaited assignment
- Verifies each case persists across snapshot restore without caller-side workarounds.
