### PR TITLE
chore(release): bump version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "quickjs-rs-python"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickjs-rs-python"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.75"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "quickjs-rs"
-version = "0.1.1"
+version = "0.1.2"
 description = "Sandboxed JavaScript execution for Python, via PyO3 + rquickjs."
 readme = "README.md"
 license = { text = "MIT" }

--- a/quickjs_rs/__init__.py
+++ b/quickjs_rs/__init__.py
@@ -21,7 +21,7 @@ from quickjs_rs.runtime import Runtime
 from quickjs_rs.snapshot import Snapshot
 from quickjs_rs.threading import ThreadWorker
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.2"
 
 __all__ = [
     "Runtime",


### PR DESCRIPTION
## Summary

Prepare the `0.1.2` release by updating project version metadata used by packaging, runtime metadata, and Rust crate lock metadata.

This aligns the repository with the release workflow, which reads the version from `pyproject.toml` and creates the `v<version>` tag after publish.

## Changes

### Version bumps

- Updated Python package version to `0.1.2` in `pyproject.toml`.
- Updated Rust crate package version to `0.1.2` in `Cargo.toml`.
- Updated exported Python runtime `__version__` to `0.1.2`.
- Updated the `quickjs-rs-python` package entry in `Cargo.lock` to `0.1.2`.

### Release alignment

- Confirmed release workflow source-of-truth is `pyproject.toml` (`project.version`) and tag format is `v<version>`.
