### PR TITLE
feat(transform): expose module transform flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,8 @@ Repository conventions for coding agents and contributors.
     scope tree / sandbox.
   - `.ts`/`.mts`/`.cts`/`.tsx` module sources are type-stripped by the host
     transform adapter (`quickjs_rs/_transform.py` driving `_transform.wasm`)
-    before the QuickJS guest receives source.
+    before the QuickJS guest receives source. Hosts may override or extend this
+    with public `SourceTransform` flags via `rt.set_module_loader(transform_flags=...)`.
 - Snapshots are whole-memory (entire guest heap; closures + pending promises
   survive); restore validates a fail-closed header incl. `build_id`.
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,37 @@ with Runtime() as rt:
 
 A TypeScript parse error surfaces as a module-load error rather than at eval.
 
+Transform flags are also public for hosts that need a different policy. For
+example, this enables the extra top-level `const` to `var` rewrite while keeping
+the default TypeScript/TSX behavior:
+
+```python
+from quickjs_rs import (
+    Runtime,
+    SourceTransform,
+    default_module_transform_flags,
+    transform_source,
+)
+
+def transform_flags(name):
+    return default_module_transform_flags(name) | SourceTransform.TOP_LEVEL_CONST_TO_VAR
+
+with Runtime() as rt:
+    rt.set_module_loader(load=sources.get, transform_flags=transform_flags)
+```
+
+Pass `SourceTransform.NONE` to disable transforms explicitly.
+
+For one-off transforms outside module loading, use `transform_source()`:
+
+```python
+js = transform_source(
+    "plain.js",
+    "export const value = 1;",
+    flags=SourceTransform.TOP_LEVEL_CONST_TO_VAR,
+)
+```
+
 ## Snapshots
 
 A snapshot captures the **entire** guest heap — every object, the atom table,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickjs-rs"
-version = "0.2.1"
+version = "0.2.2"
 description = "Sandboxed JavaScript execution for Python, via wasmtime + rquickjs."
 readme = "README.md"
 license = { text = "MIT" }

--- a/quickjs_rs/__init__.py
+++ b/quickjs_rs/__init__.py
@@ -19,6 +19,11 @@ from quickjs_rs.handle import Handle
 from quickjs_rs.runtime import Runtime
 from quickjs_rs.snapshot import Snapshot
 from quickjs_rs.threading import ThreadWorker
+from quickjs_rs.transforms import (
+    SourceTransform,
+    default_module_transform_flags,
+    transform_source,
+)
 
 __version__ = "0.2.0"
 
@@ -28,6 +33,9 @@ __all__ = [
     "Handle",
     "Snapshot",
     "ThreadWorker",
+    "SourceTransform",
+    "default_module_transform_flags",
+    "transform_source",
     "Undefined",
     "UNDEFINED",
     "QuickJSError",

--- a/quickjs_rs/_engine.py
+++ b/quickjs_rs/_engine.py
@@ -338,6 +338,7 @@ class _Instance:
         # (the guest surfaces a clean JS error).
         self.module_normalize: Callable[[str, str], str | None] | None = None
         self.module_load: Callable[[str], str | None] | None = None
+        self.module_transform_flags: int | Callable[[str], int] | None = None
         self.module_transformer = SourceTransformer()
         self._closed = False
 
@@ -569,7 +570,11 @@ class _Instance:
             source = self.module_load(name)
             if source is None:
                 return 0
-            data = self.module_transformer.transform(name, str(source)).encode()
+            data = self.module_transformer.transform(
+                name,
+                str(source),
+                flags=self._module_transform_flags(name),
+            ).encode()
             p = self.alloc_write(data)
             self.mem.write(self.store, struct.pack("<I", len(data)), out_len_ptr)
             return p
@@ -577,6 +582,16 @@ class _Instance:
             return 0
         except Exception:
             return 0
+
+    def _module_transform_flags(self, name: str) -> int | None:
+        policy = self.module_transform_flags
+        if policy is None:
+            # SourceTransformer treats None as "use the default module policy";
+            # an explicit 0/SourceTransform.NONE disables transforms.
+            return None
+        if callable(policy):
+            return int(policy(name))
+        return int(policy)
 
     # ----------------------------------------------------------------------
     # Marshalling: Python value -> guest handle.
@@ -1007,6 +1022,7 @@ class QjsRuntime:
         self._interrupt_handler: Callable[[], Any] | None = None
         self._module_normalize: Callable[[str, str], str | None] | None = None
         self._module_load: Callable[[str], str | None] | None = None
+        self._module_transform_flags: int | Callable[[str], int] | None = None
         self._instances: weakref.WeakSet[_Instance] = weakref.WeakSet()
 
     def _new_instance(self) -> _Instance:
@@ -1015,6 +1031,7 @@ class QjsRuntime:
         inst = _Instance(memory_limit=self._memory_limit, stack_limit=self._stack_limit)
         inst.module_normalize = self._module_normalize
         inst.module_load = self._module_load
+        inst.module_transform_flags = self._module_transform_flags
         inst.interrupt_handler = self._interrupt_handler
         # Apply resource limits BEFORE any eval (the first eval creates the
         # guest runtime, which reads these). set_*_limit is idempotent.
@@ -1067,15 +1084,18 @@ class QjsRuntime:
         *,
         normalize: Callable[[str, str], str | None] | None = None,
         load: Callable[[str], str | None] | None = None,
+        transform_flags: int | Callable[[str], int] | None = None,
     ) -> None:
         """Install a host module loader. normalize(base, spec) ->
         canonical name (default identity); load(name) -> source.
         Routed to every existing + future instance."""
         self._module_normalize = normalize
         self._module_load = load
+        self._module_transform_flags = transform_flags
         for inst in self._instances:
             inst.module_normalize = normalize
             inst.module_load = load
+            inst.module_transform_flags = transform_flags
 
     def close(self) -> None:
         self._closed = True

--- a/quickjs_rs/_transform.py
+++ b/quickjs_rs/_transform.py
@@ -46,7 +46,7 @@ def transform_module_source(
     name: str,
     source: str,
     *,
-    flags: int = 0,
+    flags: int | None = None,
 ) -> str:
     """Transform one source using a temporary isolated transform instance.
 
@@ -103,12 +103,14 @@ class SourceTransformer:
         name: str,
         source: str,
         *,
-        flags: int = 0,
+        flags: int | None = None,
     ) -> str:
         if self._closed:
             raise TransformError("source transformer is closed")
-        if flags == 0:
+        if flags is None:
             flags = module_transform_flags(name)
+        else:
+            flags = int(flags)
         if flags == 0:
             return source
 

--- a/quickjs_rs/runtime.py
+++ b/quickjs_rs/runtime.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 import quickjs_rs._engine as _engine
 from quickjs_rs.errors import QuickJSError
 from quickjs_rs.snapshot import Snapshot
+from quickjs_rs.transforms import TransformFlagsProvider
 
 
 def _validate_runtime_context(runtime: Runtime, ctx: Any) -> None:
@@ -115,6 +116,7 @@ class Runtime:
         *,
         normalize: Callable[[str, str], str | None] | None = None,
         load: Callable[[str], str | None],
+        transform_flags: TransformFlagsProvider | None = None,
     ) -> None:
         """Install a host module loader for ES `import`/`export` resolution
         The loader is shared by every context on this runtime.
@@ -130,6 +132,13 @@ class Runtime:
             load: ``load(canonical_name) -> source``. Return the module source
                 (a string) for a canonical name, or ``None`` if not found.
                 Required.
+            transform_flags: Optional source transform policy. ``None`` keeps
+                the default behavior: `.ts`/`.mts`/`.cts`/`.tsx` modules are
+                stripped as TypeScript/TSX based on canonical name and other
+                modules pass through unchanged. Pass a ``SourceTransform`` value
+                to apply fixed flags to every loaded module, or pass
+                ``transform_flags(name) -> SourceTransform`` to choose flags per
+                canonical name.
 
         Static imports are resolved synchronously at module instantiation, so
         these callbacks are invoked synchronously by the guest. They run on the
@@ -137,7 +146,11 @@ class Runtime:
         """
         if self._closed:
             raise QuickJSError("runtime is closed")
-        self._engine_rt.set_module_loader(normalize=normalize, load=load)
+        self._engine_rt.set_module_loader(
+            normalize=normalize,
+            load=load,
+            transform_flags=transform_flags,
+        )
 
     def restore_snapshot(
         self,

--- a/quickjs_rs/transforms.py
+++ b/quickjs_rs/transforms.py
@@ -1,0 +1,55 @@
+"""Source transform controls for module loading."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from enum import IntFlag
+
+import quickjs_rs._transform as _transform
+
+
+class SourceTransform(IntFlag):
+    """Flags controlling the OXC-backed source transform pipeline."""
+
+    NONE = 0
+    SOURCE_TS = _transform.FLAG_SOURCE_TS
+    SOURCE_TSX = _transform.FLAG_SOURCE_TSX
+    STRIP_TYPESCRIPT = _transform.FLAG_STRIP_TYPESCRIPT
+    TOP_LEVEL_CONST_TO_VAR = _transform.FLAG_TOP_LEVEL_CONST_TO_VAR
+
+
+TransformFlags = SourceTransform | int
+TransformFlagsProvider = TransformFlags | Callable[[str], TransformFlags]
+
+
+def default_module_transform_flags(name: str) -> SourceTransform:
+    """Return the default module transform flags for a canonical module name."""
+    return SourceTransform(_transform.module_transform_flags(name))
+
+
+def transform_source(
+    name: str,
+    source: str,
+    *,
+    flags: TransformFlags | None = None,
+) -> str:
+    """Transform one source string through a temporary isolated transformer.
+
+    If ``flags`` is omitted, the default module policy is derived from
+    ``name``: ``.ts``/``.mts``/``.cts`` strip as TypeScript, ``.tsx`` strips as
+    TSX, and other names pass through unchanged.
+    """
+    return _transform.transform_module_source(
+        name,
+        source,
+        flags=None if flags is None else int(flags),
+    )
+
+
+__all__ = [
+    "SourceTransform",
+    "TransformFlags",
+    "TransformFlagsProvider",
+    "default_module_transform_flags",
+    "transform_source",
+]

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -13,7 +13,7 @@ import posixpath
 
 import pytest
 
-from quickjs_rs import JSError, Runtime
+from quickjs_rs import JSError, Runtime, SourceTransform, default_module_transform_flags
 
 
 def _flat_loader(sources: dict[str, str]):
@@ -351,6 +351,87 @@ def test_js_module_is_not_stripped() -> None:
         with rt.new_context() as ctx:
             with pytest.raises(JSError):
                 ctx.eval("import { add } from 'bad.js'; add", module=True)
+
+
+def test_module_loader_can_apply_public_transform_flags_to_any_name() -> None:
+    """The host can explicitly choose TypeScript parsing independent of name."""
+    normalize, load = _flat_loader(
+        {"typed.js": "export const add = (a: number, b: number): number => a + b;"}
+    )
+    with Runtime() as rt:
+        rt.set_module_loader(
+            normalize=normalize,
+            load=load,
+            transform_flags=SourceTransform.SOURCE_TS | SourceTransform.STRIP_TYPESCRIPT,
+        )
+        with rt.new_context() as ctx:
+            with _eval_module(
+                ctx, "import { add } from 'typed.js'; export const r = add(3, 4);"
+            ) as ns:
+                r = ns.get("r")
+                try:
+                    assert r.to_python() == 7
+                finally:
+                    r.dispose()
+
+
+def test_module_loader_can_disable_default_transform_policy() -> None:
+    normalize, load = _flat_loader({"typed.ts": "export const value: number = 5;"})
+    with Runtime() as rt:
+        rt.set_module_loader(
+            normalize=normalize,
+            load=load,
+            transform_flags=SourceTransform.NONE,
+        )
+        with rt.new_context() as ctx:
+            with pytest.raises(JSError):
+                ctx.eval("import { value } from 'typed.ts'; value", module=True)
+
+
+def test_module_loader_transform_flags_callback_can_extend_defaults(monkeypatch) -> None:
+    seen_flags: list[int] = []
+
+    from quickjs_rs._transform import SourceTransformer
+
+    original_transform = SourceTransformer.transform
+
+    def record_transform(
+        self: SourceTransformer,
+        name: str,
+        source: str,
+        *,
+        flags: int | None = None,
+    ) -> str:
+        assert flags is not None
+        seen_flags.append(flags)
+        return original_transform(self, name, source, flags=flags)
+
+    monkeypatch.setattr("quickjs_rs._engine.SourceTransformer.transform", record_transform)
+
+    normalize, load = _flat_loader({"model.ts": "export const value: number = 5;"})
+
+    def flags_for(name: str) -> SourceTransform:
+        return default_module_transform_flags(name) | SourceTransform.TOP_LEVEL_CONST_TO_VAR
+
+    with Runtime() as rt:
+        rt.set_module_loader(normalize=normalize, load=load, transform_flags=flags_for)
+        with rt.new_context() as ctx:
+            with _eval_module(
+                ctx, "import { value } from 'model.ts'; export const r = value;"
+            ) as ns:
+                r = ns.get("r")
+                try:
+                    assert r.to_python() == 5
+                finally:
+                    r.dispose()
+
+    assert seen_flags == [
+        int(
+            SourceTransform.SOURCE_TS
+            | SourceTransform.STRIP_TYPESCRIPT
+            | SourceTransform.TOP_LEVEL_CONST_TO_VAR
+        )
+    ]
 
 
 def test_malformed_ts_surfaces_as_error() -> None:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,4 +1,9 @@
-from quickjs_rs import Runtime
+from quickjs_rs import (
+    Runtime,
+    SourceTransform,
+    default_module_transform_flags,
+    transform_source,
+)
 from quickjs_rs._engine import _quickjs_artifact
 from quickjs_rs._transform import (
     FLAG_SOURCE_TSX,
@@ -44,6 +49,32 @@ function f() {
     assert "export var b = 3;" in transformed
     assert "const nested = 2;" in transformed
     assert "const local = 4;" in transformed
+
+
+def test_public_transform_source_exposes_top_level_const_rewriter() -> None:
+    transformed = transform_source(
+        "plain.js",
+        "export const value = 1;",
+        flags=SourceTransform.TOP_LEVEL_CONST_TO_VAR,
+    )
+
+    assert "export var value = 1;" in transformed
+
+
+def test_public_default_module_transform_flags() -> None:
+    assert default_module_transform_flags("plain.js") == SourceTransform.NONE
+    assert default_module_transform_flags("model.ts") == (
+        SourceTransform.SOURCE_TS | SourceTransform.STRIP_TYPESCRIPT
+    )
+    assert default_module_transform_flags("view.tsx") == (
+        SourceTransform.SOURCE_TSX | SourceTransform.STRIP_TYPESCRIPT
+    )
+
+
+def test_public_transform_source_none_disables_default_policy() -> None:
+    source = "export const value: number = 1;"
+
+    assert transform_source("model.ts", source, flags=SourceTransform.NONE) == source
 
 
 def test_source_transformer_reuses_owned_instance_and_cache() -> None:
@@ -107,7 +138,7 @@ def test_module_loader_uses_context_owned_transformers(monkeypatch) -> None:
         name: str,
         source: str,
         *,
-        flags: int = 0,
+        flags: int | None = None,
     ) -> str:
         seen_transformers.append(id(self))
         return original_transform(self, name, source, flags=flags)


### PR DESCRIPTION
## Summary

Exposes the OXC transform pipeline as a public host-side API so callers can opt into additional transforms such as the top-level `const` to `var` rewrite. The default module loader behavior remains unchanged unless callers provide an explicit transform policy.

## Changes

### Public API

- Adds `SourceTransform`, `default_module_transform_flags()`, and `transform_source()` to the public `quickjs_rs` API.
- Adds `transform_flags=` to `Runtime.set_module_loader`, accepting fixed flags or a callback keyed by canonical module name.
- Distinguishes omitted flags from `SourceTransform.NONE`: omitted flags use the default TS/TSX policy, while `NONE` disables transforms explicitly.

### Module Loading

- Threads transform policy through the engine-owned module loader path so each context-owned transformer applies the selected flags before QuickJS receives source.
- Preserves the existing default `.ts`/`.mts`/`.cts`/`.tsx` stripping behavior.

### Tests and Docs

- Adds coverage for public one-off transforms, default flag lookup, explicit no-op policy, fixed loader flags, and callback loader flags.
- Documents the public transform flags and loader usage in the README and agent guidance.
