### PR TITLE
feat(transform): apply flags to eval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ Repository conventions for coding agents and contributors.
   - `.ts`/`.mts`/`.cts`/`.tsx` module sources are type-stripped by the host
     transform adapter (`quickjs_rs/_transform.py` driving `_transform.wasm`)
     before the QuickJS guest receives source. Hosts may override or extend this
-    with public `SourceTransform` flags via `rt.set_module_loader(transform_flags=...)`.
+    with public `SourceTransform` flags via `Runtime(transform_flags=...)`,
+    per-eval `transform_flags=...`, or `rt.set_module_loader(transform_flags=...)`.
 - Snapshots are whole-memory (entire guest heap; closures + pending promises
   survive); restore validates a fail-closed header incl. `build_id`.
 

--- a/README.md
+++ b/README.md
@@ -118,30 +118,57 @@ with Runtime() as rt:
 
 A TypeScript parse error surfaces as a module-load error rather than at eval.
 
-Transform flags are also public for hosts that need a different policy. For
-example, this enables the extra top-level `const` to `var` rewrite while keeping
-the default TypeScript/TSX behavior:
+Transform flags are also public for hosts that need a different policy. Runtime
+flags apply to top-level eval calls and module-loaded sources:
 
 ```python
-from quickjs_rs import (
-    Runtime,
-    SourceTransform,
-    default_module_transform_flags,
-    transform_source,
-)
+from quickjs_rs import Runtime, SourceTransform
+
+with Runtime(transform_flags=SourceTransform.TOP_LEVEL_CONST_TO_VAR) as rt:
+    with rt.new_context() as ctx:
+        ctx.eval("const exposed = 1;")
+        assert ctx.eval("globalThis.exposed") == 1
+```
+
+For TypeScript sources, choose the source kind explicitly:
+
+```python
+from quickjs_rs import Runtime, SourceTransform
+
+with Runtime(transform_flags=SourceTransform.SOURCE_TS | SourceTransform.STRIP_TYPESCRIPT) as rt:
+    with rt.new_context() as ctx:
+        assert ctx.eval("const value: number = 2; value") == 2
+```
+
+Eval calls can override the runtime policy:
+
+```python
+ctx.eval("const scoped = 1;", transform_flags=SourceTransform.NONE)
+```
+
+Module loaders can also override the runtime policy per canonical module name.
+For example, this enables the extra top-level `const` to `var` rewrite while
+keeping the default TypeScript/TSX module behavior:
+
+```python
+from quickjs_rs import SourceTransform, default_module_transform_flags
 
 def transform_flags(name):
     return default_module_transform_flags(name) | SourceTransform.TOP_LEVEL_CONST_TO_VAR
 
-with Runtime() as rt:
-    rt.set_module_loader(load=sources.get, transform_flags=transform_flags)
+rt.set_module_loader(load=sources.get, transform_flags=transform_flags)
 ```
 
-Pass `SourceTransform.NONE` to disable transforms explicitly.
+Policy precedence is: per-eval `transform_flags`, then module-loader
+`transform_flags`, then runtime `transform_flags`, then the default module
+TypeScript/TSX policy. Pass `SourceTransform.NONE` to disable transforms
+explicitly.
 
 For one-off transforms outside module loading, use `transform_source()`:
 
 ```python
+from quickjs_rs import SourceTransform, transform_source
+
 js = transform_source(
     "plain.js",
     "export const value = 1;",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickjs-rs"
-version = "0.2.2"
+version = "0.2.3"
 description = "Sandboxed JavaScript execution for Python, via wasmtime + rquickjs."
 readme = "README.md"
 license = { text = "MIT" }

--- a/quickjs_rs/_engine.py
+++ b/quickjs_rs/_engine.py
@@ -338,8 +338,9 @@ class _Instance:
         # (the guest surfaces a clean JS error).
         self.module_normalize: Callable[[str, str], str | None] | None = None
         self.module_load: Callable[[str], str | None] | None = None
+        self.runtime_transform_flags: int | Callable[[str], int] | None = None
         self.module_transform_flags: int | Callable[[str], int] | None = None
-        self.module_transformer = SourceTransformer()
+        self.source_transformer = SourceTransformer()
         self._closed = False
 
     def close(self) -> None:
@@ -361,7 +362,7 @@ class _Instance:
             return
         self._closed = True
         try:
-            self.module_transformer.close()
+            self.source_transformer.close()
         finally:
             self.store.close()
 
@@ -570,10 +571,14 @@ class _Instance:
             source = self.module_load(name)
             if source is None:
                 return 0
-            data = self.module_transformer.transform(
+            data = self.source_transformer.transform(
                 name,
                 str(source),
-                flags=self._module_transform_flags(name),
+                flags=self._source_transform_flags(
+                    name,
+                    override=self.module_transform_flags,
+                    use_module_default=True,
+                ),
             ).encode()
             p = self.alloc_write(data)
             self.mem.write(self.store, struct.pack("<I", len(data)), out_len_ptr)
@@ -583,12 +588,35 @@ class _Instance:
         except Exception:
             return 0
 
-    def _module_transform_flags(self, name: str) -> int | None:
-        policy = self.module_transform_flags
+    def transform_eval_source(
+        self,
+        filename: str,
+        source: str,
+        *,
+        transform_flags: int | Callable[[str], int] | None,
+    ) -> str:
+        flags = self._source_transform_flags(
+            filename,
+            override=transform_flags,
+            use_module_default=False,
+        )
+        try:
+            return self.source_transformer.transform(filename, source, flags=flags)
+        except TransformError as e:
+            raise JSError("SyntaxError", str(e), None) from None
+
+    def _source_transform_flags(
+        self,
+        name: str,
+        *,
+        override: int | Callable[[str], int] | None,
+        use_module_default: bool,
+    ) -> int | None:
+        policy = override if override is not None else self.runtime_transform_flags
         if policy is None:
-            # SourceTransformer treats None as "use the default module policy";
-            # an explicit 0/SourceTransform.NONE disables transforms.
-            return None
+            # SourceTransformer treats None as "use the default module policy".
+            # For top-level eval, no policy means no transform.
+            return None if use_module_default else 0
         if callable(policy):
             return int(policy(name))
         return int(policy)
@@ -1015,9 +1043,16 @@ class QjsRuntime:
     it is a deliberate later (user-facing) decision.
     """
 
-    def __init__(self, *, memory_limit: int | None = None, stack_limit: int | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        memory_limit: int | None = None,
+        stack_limit: int | None = None,
+        transform_flags: int | Callable[[str], int] | None = None,
+    ) -> None:
         self._memory_limit = memory_limit
         self._stack_limit = stack_limit
+        self._transform_flags = transform_flags
         self._closed = False
         self._interrupt_handler: Callable[[], Any] | None = None
         self._module_normalize: Callable[[str, str], str | None] | None = None
@@ -1031,6 +1066,7 @@ class QjsRuntime:
         inst = _Instance(memory_limit=self._memory_limit, stack_limit=self._stack_limit)
         inst.module_normalize = self._module_normalize
         inst.module_load = self._module_load
+        inst.runtime_transform_flags = self._transform_flags
         inst.module_transform_flags = self._module_transform_flags
         inst.interrupt_handler = self._interrupt_handler
         # Apply resource limits BEFORE any eval (the first eval creates the
@@ -1120,9 +1156,20 @@ class QjsContext:
 
     # -- eval --
     def eval(
-        self, code: str, *, module: bool = False, strict: bool = False, filename: str = "<eval>"
+        self,
+        code: str,
+        *,
+        module: bool = False,
+        strict: bool = False,
+        filename: str = "<eval>",
+        transform_flags: int | Callable[[str], int] | None = None,
     ) -> Any:
-        handle = self._eval_to_handle(code, module=module)
+        handle = self._eval_to_handle(
+            code,
+            module=module,
+            filename=filename,
+            transform_flags=transform_flags,
+        )
         try:
             return self._inst.handle_to_python(handle, allow_opaque=False)
         finally:
@@ -1136,17 +1183,33 @@ class QjsContext:
         strict: bool = False,
         promise: bool = False,
         filename: str = "<eval>",
+        transform_flags: int | Callable[[str], int] | None = None,
     ) -> QjsHandle:
         # promise=True → JS_EVAL_FLAG_ASYNC (the guest `eval_async`), which
         # supports top-level await + multi-statement bodies and returns a
         # Promise handle that resolves to the {value} envelope.
         if promise:
-            handle = self._eval_async_to_handle(code)
+            handle = self._eval_async_to_handle(
+                code,
+                filename=filename,
+                transform_flags=transform_flags,
+            )
         else:
-            handle = self._eval_to_handle(code, module=module)
+            handle = self._eval_to_handle(
+                code,
+                module=module,
+                filename=filename,
+                transform_flags=transform_flags,
+            )
         return QjsHandle._adopt(self._inst, handle, context=self)
 
-    def eval_module_async(self, code: str, *, filename: str = "<eval>") -> QjsHandle:
+    def eval_module_async(
+        self,
+        code: str,
+        *,
+        filename: str = "<eval>",
+        transform_flags: int | Callable[[str], int] | None = None,
+    ) -> QjsHandle:
         # Module eval returning a Promise (Module::evaluate). Our guest's
         # eval_module evaluates synchronously and returns the namespace; wrap it
         # as an already-settled promise shape by re-evaluating under async eval
@@ -1154,10 +1217,27 @@ class QjsContext:
         # handle the drive loop treats as settled. context.py expects a Promise;
         # eval_module's result isn't one, so route module-async through the same
         # async eval path which DOES produce a promise.
-        handle = self._eval_async_to_handle(code, module=True)
+        handle = self._eval_async_to_handle(
+            code,
+            module=True,
+            filename=filename,
+            transform_flags=transform_flags,
+        )
         return QjsHandle._adopt(self._inst, handle, context=self)
 
-    def _eval_to_handle(self, code: str, *, module: bool) -> int:
+    def _eval_to_handle(
+        self,
+        code: str,
+        *,
+        module: bool,
+        filename: str,
+        transform_flags: int | Callable[[str], int] | None,
+    ) -> int:
+        code = self._inst.transform_eval_source(
+            filename,
+            code,
+            transform_flags=transform_flags,
+        )
         data = code.encode()
         inst = self._inst
         p = inst.alloc_write(data)
@@ -1183,13 +1263,25 @@ class QjsContext:
             raise JSError("Error", f"eval status={st}", None)
         return handle
 
-    def _eval_async_to_handle(self, code: str, *, module: bool = False) -> int:
+    def _eval_async_to_handle(
+        self,
+        code: str,
+        *,
+        module: bool = False,
+        filename: str = "<eval>",
+        transform_flags: int | Callable[[str], int] | None = None,
+    ) -> int:
         """Return a Promise handle the host drives to completion (settling async
         host calls + draining microtasks). For `module=True` the guest's
         `eval_module_async` compiles+links the module and returns its top-level
         -await promise; otherwise `eval_async` does JS_EVAL_FLAG_ASYNC script
         eval (the {value} envelope)."""
         inst = self._inst
+        code = inst.transform_eval_source(
+            filename,
+            code,
+            transform_flags=transform_flags,
+        )
         data = code.encode()
         p = inst.alloc_write(data)
         out = inst.alloc_out()

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -27,6 +27,7 @@ from quickjs_rs.globals import Globals
 from quickjs_rs.handle import Handle
 from quickjs_rs.runtime import Runtime
 from quickjs_rs.snapshot import Snapshot
+from quickjs_rs.transforms import TransformFlagsProvider
 
 _HOST_ERROR_SANITIZED_MESSAGE = "Host function failed"
 
@@ -178,12 +179,14 @@ class Context:
         module: bool = False,
         strict: bool = False,
         filename: str = "<eval>",
+        transform_flags: TransformFlagsProvider | None = None,
     ) -> Handle:
         """Evaluate JS code and return the result as an opaque Handle.
 
         Unlike :meth:`eval`, the result is never marshaled — functions,
         symbols, promises, and other opaque values all come back as
-        Handles.
+        Handles. ``transform_flags`` overrides the runtime transform policy for
+        this call; pass ``SourceTransform.NONE`` to disable transforms.
         """
         if self._closed:
             raise QuickJSError("context is closed")
@@ -200,6 +203,7 @@ class Context:
                 module=module,
                 strict=strict,
                 filename=filename,
+                transform_flags=transform_flags,
             )
         except _engine.JSError as e:
             name, message, stack = e.args
@@ -224,12 +228,15 @@ class Context:
         module: bool = False,
         strict: bool = False,
         filename: str = "<eval>",
+        transform_flags: TransformFlagsProvider | None = None,
     ) -> Any:
         """Evaluate JS code and return the result as a Python value.
 
-        Tthe wall-clock timeout is measured from the start of
+        The wall-clock timeout is measured from the start of
         each call. The runtime's interrupt handler reads the deadline
-        written here and aborts execution when it elapses.
+        written here and aborts execution when it elapses. ``transform_flags``
+        overrides the runtime transform policy for this call; pass
+        ``SourceTransform.NONE`` to disable transforms.
         """
         if self._closed:
             raise QuickJSError("context is closed")
@@ -253,6 +260,7 @@ class Context:
                 module=module,
                 strict=strict,
                 filename=filename,
+                transform_flags=transform_flags,
             )
         except _engine.JSError as e:
             name, message, stack = e.args
@@ -475,6 +483,7 @@ class Context:
         strict: bool = False,
         filename: str = "<eval>",
         timeout: float | None = None,
+        transform_flags: TransformFlagsProvider | None = None,
     ) -> Any:
         """Evaluate code with top-level await + async host-call support.
 
@@ -496,6 +505,8 @@ class Context:
 
         Timeout semantics: ``timeout`` overrides this call's deadline.
         If omitted, the context default timeout is used for this call.
+        ``transform_flags`` overrides the runtime transform policy for this
+        call; pass ``SourceTransform.NONE`` to disable transforms.
 
         Cancellation: if the enclosing asyncio task is cancelled,
         the driving loop rejects in-flight host-call Promises with a
@@ -510,6 +521,7 @@ class Context:
             strict=strict,
             filename=filename,
             timeout=timeout,
+            transform_flags=transform_flags,
         )
         # Settled is a Handle; marshal to Python. Two unwrap paths:
         #
@@ -539,13 +551,16 @@ class Context:
         strict: bool = False,
         filename: str = "<eval>",
         timeout: float | None = None,
+        transform_flags: TransformFlagsProvider | None = None,
     ) -> Handle:
         """Same driving flow as :meth:`eval_async`, but return the
         settled value as a :class:`Handle` rather than marshaling.
 
         Timeout semantics match :meth:`eval_async`: ``timeout``
         overrides this call's deadline, and the context default is
-        used when omitted.
+        used when omitted. ``transform_flags`` overrides the runtime transform
+        policy for this call; pass ``SourceTransform.NONE`` to disable
+        transforms.
 
         ``module=True``: returns a Handle to ``undefined`` (ES
         modules complete with undefined). The module's exports are
@@ -558,6 +573,7 @@ class Context:
             strict=strict,
             filename=filename,
             timeout=timeout,
+            transform_flags=transform_flags,
         )
         if module:
             # The settled promise resolves to undefined; just return
@@ -577,6 +593,7 @@ class Context:
         strict: bool,
         filename: str,
         timeout: float | None,
+        transform_flags: TransformFlagsProvider | None,
     ) -> Handle:
         """Shared prologue + eval + driving loop for eval_async and
         eval_handle_async. Returns a Handle to the settled value
@@ -604,7 +621,14 @@ class Context:
         self._runtime._deadline = deadline
         try:
             settled = await self._run_inside_task_group(
-                lambda: self._eval_for_async(code, module, strict, filename, deadline),
+                lambda: self._eval_for_async(
+                    code,
+                    module,
+                    strict,
+                    filename,
+                    deadline,
+                    transform_flags,
+                ),
                 deadline,
             )
         finally:
@@ -619,6 +643,7 @@ class Context:
         strict: bool,
         filename: str,
         deadline: float,
+        transform_flags: TransformFlagsProvider | None,
     ) -> Handle:
         """Synchronous eval inside an already-open TaskGroup scope.
         Any async host calls dispatched during this eval become
@@ -638,6 +663,7 @@ class Context:
                 inner = self._engine_ctx.eval_module_async(
                     code,
                     filename=filename,
+                    transform_flags=transform_flags,
                 )
             else:
                 inner = self._engine_ctx.eval_handle(
@@ -646,6 +672,7 @@ class Context:
                     strict=strict,
                     promise=True,
                     filename=filename,
+                    transform_flags=transform_flags,
                 )
         except _engine.JSError as e:
             name, message, stack = e.args

--- a/quickjs_rs/runtime.py
+++ b/quickjs_rs/runtime.py
@@ -33,7 +33,9 @@ class Runtime:
     Per-eval deadlines are written into ``self._deadline`` by the
     ``Context`` layer before each eval and cleared after; the handler
     reads that slot on every QuickJS interrupt poll and returns True
-    once the deadline has elapsed.
+    once the deadline has elapsed. ``transform_flags`` sets the default
+    source transform policy for top-level eval calls and module-loaded
+    sources.
     """
 
     def __init__(
@@ -41,11 +43,13 @@ class Runtime:
         *,
         memory_limit: int | None = 64 * 1024 * 1024,
         stack_limit: int | None = 1 * 1024 * 1024,
+        transform_flags: TransformFlagsProvider | None = None,
     ) -> None:
         try:
             self._engine_rt = _engine.QjsRuntime(
                 memory_limit=memory_limit,
                 stack_limit=stack_limit,
+                transform_flags=transform_flags,
             )
         except _engine.QuickJSError as e:
             raise QuickJSError(str(e)) from e
@@ -132,13 +136,14 @@ class Runtime:
             load: ``load(canonical_name) -> source``. Return the module source
                 (a string) for a canonical name, or ``None`` if not found.
                 Required.
-            transform_flags: Optional source transform policy. ``None`` keeps
-                the default behavior: `.ts`/`.mts`/`.cts`/`.tsx` modules are
-                stripped as TypeScript/TSX based on canonical name and other
-                modules pass through unchanged. Pass a ``SourceTransform`` value
-                to apply fixed flags to every loaded module, or pass
-                ``transform_flags(name) -> SourceTransform`` to choose flags per
-                canonical name.
+            transform_flags: Optional module source transform policy. ``None``
+                inherits the runtime transform policy; if the runtime has none,
+                `.ts`/`.mts`/`.cts`/`.tsx` modules are stripped as
+                TypeScript/TSX based on canonical name and other modules pass
+                through unchanged. Pass a ``SourceTransform`` value to apply
+                fixed flags to every loaded module, or pass
+                ``transform_flags(name) -> SourceTransform`` to choose flags
+                per canonical name.
 
         Static imports are resolved synchronously at module instantiation, so
         these callbacks are invoked synchronously by the guest. They run on the

--- a/quickjs_rs/transforms.py
+++ b/quickjs_rs/transforms.py
@@ -1,4 +1,4 @@
-"""Source transform controls for module loading."""
+"""Source transform controls for eval and module loading."""
 
 from __future__ import annotations
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -388,6 +388,38 @@ def test_module_loader_can_disable_default_transform_policy() -> None:
                 ctx.eval("import { value } from 'typed.ts'; value", module=True)
 
 
+def test_module_loader_inherits_runtime_transform_policy() -> None:
+    normalize, load = _flat_loader({"typed.js": "export const value: number = 16;"})
+    with Runtime(
+        transform_flags=SourceTransform.SOURCE_TS | SourceTransform.STRIP_TYPESCRIPT
+    ) as rt:
+        rt.set_module_loader(normalize=normalize, load=load)
+        with rt.new_context() as ctx:
+            with _eval_module(
+                ctx, "import { value } from 'typed.js'; export const r = value;"
+            ) as ns:
+                r = ns.get("r")
+                try:
+                    assert r.to_python() == 16
+                finally:
+                    r.dispose()
+
+
+def test_module_loader_transform_flags_override_runtime_policy() -> None:
+    normalize, load = _flat_loader({"typed.ts": "export const value: number = 17;"})
+    with Runtime(
+        transform_flags=SourceTransform.SOURCE_TS | SourceTransform.STRIP_TYPESCRIPT
+    ) as rt:
+        rt.set_module_loader(
+            normalize=normalize,
+            load=load,
+            transform_flags=SourceTransform.NONE,
+        )
+        with rt.new_context() as ctx:
+            with pytest.raises(JSError):
+                ctx.eval("import { value } from 'typed.ts'; value", module=True)
+
+
 def test_module_loader_transform_flags_callback_can_extend_defaults(monkeypatch) -> None:
     seen_flags: list[int] = []
 
@@ -402,8 +434,9 @@ def test_module_loader_transform_flags_callback_can_extend_defaults(monkeypatch)
         *,
         flags: int | None = None,
     ) -> str:
-        assert flags is not None
-        seen_flags.append(flags)
+        if name == "model.ts":
+            assert flags is not None
+            seen_flags.append(flags)
         return original_transform(self, name, source, flags=flags)
 
     monkeypatch.setattr("quickjs_rs._engine.SourceTransformer.transform", record_transform)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -77,6 +77,60 @@ def test_public_transform_source_none_disables_default_policy() -> None:
     assert transform_source("model.ts", source, flags=SourceTransform.NONE) == source
 
 
+def test_runtime_transform_flags_apply_to_eval() -> None:
+    with Runtime(transform_flags=SourceTransform.TOP_LEVEL_CONST_TO_VAR) as rt:
+        with rt.new_context() as ctx:
+            ctx.eval("const runtimeEvalValue = 11;")
+
+            assert ctx.eval("globalThis.runtimeEvalValue") == 11
+
+
+def test_eval_transform_flags_override_runtime_policy() -> None:
+    with Runtime(transform_flags=SourceTransform.TOP_LEVEL_CONST_TO_VAR) as rt:
+        with rt.new_context() as ctx:
+            ctx.eval("const scopedValue = 12;", transform_flags=SourceTransform.NONE)
+
+            assert ctx.eval("'scopedValue' in globalThis") is False
+
+
+def test_eval_handle_transform_flags_apply_to_top_level_eval() -> None:
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+            with ctx.eval_handle(
+                "const handleEvalValue = {answer: 13}; globalThis.handleEvalValue",
+                transform_flags=SourceTransform.TOP_LEVEL_CONST_TO_VAR,
+            ) as handle:
+                answer = handle.get("answer")
+                try:
+                    assert answer.to_python() == 13
+                finally:
+                    answer.dispose()
+
+
+async def test_runtime_transform_flags_apply_to_eval_async() -> None:
+    with Runtime(transform_flags=SourceTransform.TOP_LEVEL_CONST_TO_VAR) as rt:
+        with rt.new_context() as ctx:
+            assert (
+                await ctx.eval_async(
+                    "const asyncEvalValue = 14; globalThis.asyncEvalValue"
+                )
+                == 14
+            )
+
+
+async def test_eval_handle_async_transform_flags_apply_to_top_level_eval() -> None:
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+            handle = await ctx.eval_handle_async(
+                "const asyncHandleValue: number = 15; asyncHandleValue",
+                transform_flags=SourceTransform.SOURCE_TS | SourceTransform.STRIP_TYPESCRIPT,
+            )
+            try:
+                assert handle.to_python() == 15
+            finally:
+                handle.dispose()
+
+
 def test_source_transformer_reuses_owned_instance_and_cache() -> None:
     transformer = SourceTransformer()
     source = "export const x: number = 1;"
@@ -140,7 +194,8 @@ def test_module_loader_uses_context_owned_transformers(monkeypatch) -> None:
         *,
         flags: int | None = None,
     ) -> str:
-        seen_transformers.append(id(self))
+        if name == "x.ts":
+            seen_transformers.append(id(self))
         return original_transform(self, name, source, flags=flags)
 
     monkeypatch.setattr("quickjs_rs._engine.SourceTransformer.transform", record_transform)


### PR DESCRIPTION
## Summary

Extends the public source transform policy from module loading to top-level eval paths. Runtime-level transform flags now provide the default policy for eval and module-loaded sources, while per-eval and module-loader flags can still override that behavior.

## Changes

`quickjs_rs` now accepts `Runtime(transform_flags=...)` and threads that policy into each context-owned wasm instance. Sync eval, async eval, eval handles, and module async eval all run through the shared source transformer before QuickJS receives source.

Public context eval APIs now accept `transform_flags=...` overrides, including `SourceTransform.NONE` to disable transforms for a single call. Module loading preserves the existing default TypeScript/TSX behavior when no runtime or loader policy is set, and otherwise follows the explicit precedence documented in the README.

Tests cover runtime eval transforms, per-call overrides, async eval transforms, module-loader inheritance, and module-loader overrides.
