### PR TITLE
fix(quickjs_rs): unsettled promises always raise deadlock errors

### DIFF
--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -1032,7 +1032,7 @@ class Context:
                 # promise resurfaces later as an abiguous DeadlockError that
                 # discards the true root cause. Here, we settle it anyway, and keep
                 # the original exception reachable.
-                
+
                 settle_exc = _public_engine_error(settle_exc)
                 settled = False
                 if resolve_ok:

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -112,6 +112,10 @@ class Context:
         # into it instead of loop.create_task.
         self._eval_async_in_flight = False
         self._pending_tasks: dict[int, asyncio.Task[Any]] = {}
+        # Async host calls whose result could NOT be delivered into the guest
+        # (resolve_pending/reject_pending both raised). Kept so the driving
+        # loop can surface a clear error rather than a bare DeadlockError.
+        self._failed_settles: dict[int, BaseException] = {}
         self._pending_completed: asyncio.Event | None = None
         self._active_task_group: asyncio.TaskGroup | None = None
 
@@ -767,6 +771,27 @@ class Context:
 
                             # Step 5/6: pending.
                             if not self._pending_tasks:
+                                if self._failed_settles:
+                                    # A host call completed but its result could not be delivered
+                                    # because resolve or reject raised. We reject those promises
+                                    # now so the await surfaces a catchable error instead of an,
+                                    # ambiguous deadlock error. The original cause is captured
+                                    # via _last_host_exception which helps with diagnosing issues
+                                    # in the future.
+                                    stuck = self._failed_settles
+                                    self._failed_settles = {}
+                                    for pid, exc in stuck.items():
+                                        self._last_host_exception = exc
+                                        try:
+                                            self._engine_ctx.reject_pending(
+                                                pid,
+                                                "HostError",
+                                                _HOST_ERROR_SANITIZED_MESSAGE,
+                                                None,
+                                            )
+                                        except Exception:
+                                            pass
+                                    continue
                                 raise DeadlockError(
                                     "eval_async's top-level promise "
                                     "is pending but no async host "
@@ -985,11 +1010,39 @@ class Context:
                     self._engine_ctx.resolve_pending(pending_id, value)
                 else:
                     self._engine_ctx.reject_pending(pending_id, err_name, err_message, err_stack)
-            except Exception:
-                # Benign: the context may have closed under us, or
-                # the pid was already settled by the cancellation
-                # walk.
-                pass
+            except Exception as settle_exc:
+                # The promise was not settled. Two causes are genuinely benign:
+                #   1. the context closed under us
+                #   2. the pid was already settled by the cancellation walk
+                # But a real failure, e.g., the result could not be marshaled back
+                # into the guest should not be swallowed otherwise an unsettled
+                # promise resurfaces later as an abiguous DeadlockError that
+                # discards the true root cause. Here, we settle it anyway, and keep
+                # the original exception reachable.
+                settled = False
+                if resolve_ok:
+                    # Retry once for potential transient failures
+                    try:
+                        self._engine_ctx.run_pending_jobs()
+                        self._engine_ctx.resolve_pending(pending_id, value)
+                        settled = True
+                    except Exception:
+                        # Still can't deliver the result. Store the original
+                        # exception so the eval boundary can re-raises it.
+                        self._last_host_exception = settle_exc
+                if not settled:
+                    try:
+                        self._engine_ctx.reject_pending(
+                            pending_id, err_name, _HOST_ERROR_SANITIZED_MESSAGE, None
+                        )
+                        settled = True
+                    except Exception:
+                        settled = False
+                if not settled:
+                    # Could neither resolve nor reject. Record so the driving loop
+                    # surfaces a clear error rather than a bare deadlock error to
+                    # keep the original cause.
+                    self._failed_settles[pending_id] = settle_exc
         finally:
             self._pending_tasks.pop(pending_id, None)
             if self._pending_completed is not None:

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -32,6 +32,19 @@ from quickjs_rs.transforms import TransformFlagsProvider
 _HOST_ERROR_SANITIZED_MESSAGE = "Host function failed"
 
 
+def _public_engine_error(exc: BaseException) -> BaseException:
+    """Map an internal `_engine.*` exception to its public `errors.*`
+    counterpart so a settle failure can leave the eval boundary as part of the
+    public API — the same internal→public conversion `eval_handle` performs
+    for sync evals. Non-engine exceptions are returned unchanged.
+    """
+    if isinstance(exc, _engine.MarshalError):
+        return MarshalError(str(exc))
+    if isinstance(exc, _engine.QuickJSError):
+        return QuickJSError(str(exc))
+    return exc
+
+
 def _detect_is_async(fn: Callable[..., Any]) -> bool:
     """Infer async-ness of a registered host function.
 
@@ -1019,6 +1032,8 @@ class Context:
                 # promise resurfaces later as an abiguous DeadlockError that
                 # discards the true root cause. Here, we settle it anyway, and keep
                 # the original exception reachable.
+                
+                settle_exc = _public_engine_error(settle_exc)
                 settled = False
                 if resolve_ok:
                     # Retry once for potential transient failures

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -32,7 +32,7 @@ from quickjs_rs.transforms import TransformFlagsProvider
 _HOST_ERROR_SANITIZED_MESSAGE = "Host function failed"
 
 
-def _public_engine_error(exc: BaseException) -> BaseException:
+def _public_engine_error(exc: Exception) -> Exception:
     """Map an internal `_engine.*` exception to its public `errors.*`
     counterpart so a settle failure can leave the eval boundary as part of the
     public API. The same internal→public conversion `eval_handle` performs

--- a/quickjs_rs/context.py
+++ b/quickjs_rs/context.py
@@ -35,7 +35,7 @@ _HOST_ERROR_SANITIZED_MESSAGE = "Host function failed"
 def _public_engine_error(exc: BaseException) -> BaseException:
     """Map an internal `_engine.*` exception to its public `errors.*`
     counterpart so a settle failure can leave the eval boundary as part of the
-    public API — the same internal→public conversion `eval_handle` performs
+    public API. The same internal→public conversion `eval_handle` performs
     for sync evals. Non-engine exceptions are returned unchanged.
     """
     if isinstance(exc, _engine.MarshalError):

--- a/tests/test_settle_failure.py
+++ b/tests/test_settle_failure.py
@@ -1,0 +1,118 @@
+"""Async host-call settle failures surface as catchable errors, not deadlocks.
+
+When a host call completes but its result cannot be delivered into the guest
+(``resolve_pending`` raises — e.g. the value can't be marshaled), the driving
+loop must NOT leave the promise pending and report a spurious ``DeadlockError``.
+Instead it retries once, then rejects the promise, threading the original
+exception out via the host-exception side channel so the real cause surfaces.
+
+``DeadlockError`` is reserved for a genuinely un-resolvable promise (no resolver
+and no host work in flight).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from quickjs_rs import DeadlockError, MarshalError, Runtime
+
+
+def _nested(depth: int) -> dict:
+    """A chain of ``depth`` nested dicts — exceeds the marshal recursion
+    limit (``_MAX_MARSHAL_DEPTH`` == 128) for large ``depth``."""
+    root: dict = {}
+    cur = root
+    for _ in range(depth):
+        nxt: dict = {}
+        cur["x"] = nxt
+        cur = nxt
+    return root
+
+
+async def test_unmarshalable_result_rejects_not_deadlock() -> None:
+    """A result too deeply nested to marshal back surfaces as a catchable
+    MarshalError, not a DeadlockError."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+
+            async def bad_result() -> dict:
+                return _nested(200)
+
+            ctx.register("badResult", bad_result, is_async=True)
+            with pytest.raises(MarshalError):
+                await ctx.eval_async("await badResult()", module=False)
+
+
+async def test_nonmarshalable_leaf_rejects_not_deadlock() -> None:
+    """A non-marshalable leaf type (a Python set) surfaces as MarshalError,
+    not a DeadlockError, and names the real cause."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+
+            async def set_result() -> set:
+                return {1, 2, 3}
+
+            ctx.register("setResult", set_result, is_async=True)
+            with pytest.raises(MarshalError, match="cannot marshal"):
+                await ctx.eval_async("await setResult()", module=False)
+
+
+async def test_promise_all_with_one_unmarshalable_rejects() -> None:
+    """Mirrors the agent fan-out: Promise.all over several host calls where one
+    result can't be delivered. The batch rejects with the real error — it does
+    not hang or deadlock, and the healthy siblings don't mask the failure."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+
+            async def bad_result() -> dict:
+                return _nested(200)
+
+            async def good() -> dict:
+                return {"ok": 1}
+
+            ctx.register("badResult", bad_result, is_async=True)
+            ctx.register("good", good, is_async=True)
+            with pytest.raises(MarshalError):
+                await ctx.eval_async(
+                    "await Promise.all([badResult(), good()])", module=False
+                )
+
+
+async def test_original_cause_is_surfaced() -> None:
+    """The exception the agent sees is the real marshaling failure, not the
+    generic 'missing resolver' deadlock text — i.e. the cause is threaded out
+    rather than swallowed."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+
+            async def bad_result() -> dict:
+                return _nested(200)
+
+            ctx.register("badResult", bad_result, is_async=True)
+            with pytest.raises(MarshalError) as excinfo:
+                await ctx.eval_async("await badResult()", module=False)
+            assert "recursion limit" in str(excinfo.value)
+            assert not isinstance(excinfo.value, DeadlockError)
+
+
+async def test_resolver_less_await_still_deadlocks() -> None:
+    """Regression guard: the settle-failure recovery must NOT suppress a
+    genuine dead-end. A promise with no resolver and no host work in flight
+    still raises DeadlockError."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+            with pytest.raises(DeadlockError):
+                await ctx.eval_async("await new Promise(() => {})", module=False)
+
+
+async def test_healthy_async_result_unaffected() -> None:
+    """Control: the fix does not touch the happy path — a normal async host
+    result still resolves and marshals back."""
+    with Runtime() as rt:
+        with rt.new_context() as ctx:
+
+            async def good() -> dict:
+                return {"ok": 1}
+
+            ctx.register("good", good, is_async=True)
+            assert await ctx.eval_async("await good()", module=False) == {"ok": 1}


### PR DESCRIPTION
### Summary

We occasionally see deadlock exceptions in traces when using the code interpreter and dynamic subagents:
```
<error type="Deadlock">eval_async's top-level promise is pending but no async host calls are in flight. Did you forget to register a function as async (is_async=True)? Or is a JS Promise missing its resolver?</error>
```

The root cause is that the host count of pending tasks gets out of sync with the in flight promises in JS. The current code path ALWAYS treats this as an ambiguous deadlock error without providing information about why the promise couldn't be settled.

The change in this PR does a few things:
1. Sets up a retry on failed resolves or rejects in the event of it being transient
2. Stores the exception due to a failed resolve or reject to be surfaced for better visibility into what the true root cause was
3. Maintains the deadlock error in the event that there are no failed settles and a true deadlock situation occurs

### Tests
- Unit tests
- E2E tests where I was able to deterministically repro the issue. For example,
Before:
```
<error type="Deadlock">eval_async's top-level promise is pending but no async host calls are in flight. Did you forget to register a function as async (is_async=True)? Or is a JS Promise missing its resolver?</error>
```

After:
```
MarshalError: recursion limit exceeded while marshaling
```

This gives a much better opportunity to understand the true root cause.