### PR TITLE
chore(release): bump version to 0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quickjs-rs"
-version = "0.2.4"
+version = "0.2.5"
 description = "Sandboxed JavaScript execution for Python, via wasmtime + rquickjs."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

Bumps the `quickjs-rs` package version from `0.2.4` to `0.2.5`
